### PR TITLE
feat: PMS 테스트/결함 관리 시스템 구현 및 성능 최적화

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -83,5 +83,8 @@
 	<classpathentry kind="lib" path="C:/InswaveToolSP1/workspace/InsWebApp/src/main/webapp/WEB-INF/lib/xmlbeans-xmlpublic-2.5.0.jar"/>
 	<classpathentry kind="lib" path="C:/InswaveToolSP1/workspace/InsWebApp/src/main/webapp/WEB-INF/lib/matrix_mobile_server-1.3.7.0.jar"/>
 	<classpathentry kind="lib" path="C:/InswaveToolSP1/workspace/InsWebApp/src/main/webapp/WEB-INF/lib/snakeyaml-1.27.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
+	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.module.container"/>
+	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/org.eclipse.jst.server.tomcat.runtimeTarget/Apache Tomcat v9.0"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/com/demo/proworks/defect/dao/DefDAO.java
+++ b/src/main/java/com/demo/proworks/defect/dao/DefDAO.java
@@ -1,0 +1,92 @@
+package com.demo.proworks.defect.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.inswave.elfw.exception.ElException;
+import com.demo.proworks.defect.vo.DefVo;
+import com.demo.proworks.defect.dao.DefDAO;
+
+/**  
+ * @subject     : 테스트결함관리 관련 처리를 담당하는 DAO
+ * @description : 테스트결함관리 관련 처리를 담당하는 DAO
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Repository("defDAO")
+public class DefDAO extends com.demo.proworks.cmmn.dao.ProworksDefaultAbstractDAO {
+
+    /**
+     * 테스트결함관리 상세 조회한다.
+     *  
+     * @param  DefVo 테스트결함관리
+     * @return DefVo 테스트결함관리
+     * @throws ElException
+     */
+    public DefVo selectDef(DefVo vo) throws ElException {
+        return (DefVo) selectByPk("com.demo.proworks.defect.selectDef", vo);
+    }
+
+    /**
+     * 페이징을 처리하여 테스트결함관리 목록조회를 한다.
+     *  
+     * @param  DefVo 테스트결함관리
+     * @return List<DefVo> 테스트결함관리
+     * @throws ElException
+     */
+    public List<DefVo> selectListDef(DefVo vo) throws ElException {      	
+        return (List<DefVo>)list("com.demo.proworks.defect.selectListDef", vo);
+    }
+
+    /**
+     * 테스트결함관리 목록 조회의 전체 카운트를 조회한다.
+     *  
+     * @param  DefVo 테스트결함관리
+     * @return 테스트결함관리 조회의 전체 카운트
+     * @throws ElException
+     */
+    public long selectListCountDef(DefVo vo)  throws ElException{               
+        return (Long)selectByPk("com.demo.proworks.defect.selectListCountDef", vo);
+    }
+        
+    /**
+     * 테스트결함관리를 등록한다.
+     *  
+     * @param  DefVo 테스트결함관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int insertDef(DefVo vo) throws ElException {    	
+        return insert("com.demo.proworks.defect.insertDef", vo);
+    }
+
+    /**
+     * 테스트결함관리를 갱신한다.
+     *  
+     * @param  DefVo 테스트결함관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int updateDef(DefVo vo) throws ElException {
+        return update("com.demo.proworks.defect.updateDef", vo);
+    }
+
+    /**
+     * 테스트결함관리를 삭제한다.
+     *  
+     * @param  DefVo 테스트결함관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int deleteDef(DefVo vo) throws ElException {
+        return delete("com.demo.proworks.defect.deleteDef", vo);
+    }
+
+}

--- a/src/main/java/com/demo/proworks/defect/service/DefService.java
+++ b/src/main/java/com/demo/proworks/defect/service/DefService.java
@@ -1,0 +1,75 @@
+package com.demo.proworks.defect.service;
+
+import java.util.List;
+
+import com.demo.proworks.defect.vo.DefVo;
+
+/**  
+ * @subject     : 테스트결함관리 관련 처리를 담당하는 인터페이스
+ * @description : 테스트결함관리 관련 처리를 담당하는 인터페이스
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+public interface DefService {
+	
+    /**
+     * 테스트결함관리 페이징 처리하여 목록을 조회한다.
+     *
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 테스트결함관리 목록 List<DefVo>
+     * @throws Exception
+     */
+	public List<DefVo> selectListDef(DefVo defVo) throws Exception;
+	
+    /**
+     * 조회한 테스트결함관리 전체 카운트
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 테스트결함관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountDef(DefVo defVo) throws Exception;
+	
+    /**
+     * 테스트결함관리를 상세 조회한다.
+     *
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public DefVo selectDef(DefVo defVo) throws Exception;
+		
+    /**
+     * 테스트결함관리를 등록 처리 한다.
+     *
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertDef(DefVo defVo) throws Exception;
+	
+    /**
+     * 테스트결함관리를 갱신 처리 한다.
+     *
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateDef(DefVo defVo) throws Exception;
+	
+    /**
+     * 테스트결함관리를 삭제 처리 한다.
+     *
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteDef(DefVo defVo) throws Exception;
+	
+}

--- a/src/main/java/com/demo/proworks/defect/service/impl/DefServiceImpl.java
+++ b/src/main/java/com/demo/proworks/defect/service/impl/DefServiceImpl.java
@@ -1,0 +1,125 @@
+package com.demo.proworks.defect.service.impl;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import com.demo.proworks.defect.service.DefService;
+import com.demo.proworks.defect.vo.DefVo;
+import com.demo.proworks.defect.dao.DefDAO;
+
+/**  
+ * @subject     : 테스트결함관리 관련 처리를 담당하는 ServiceImpl
+ * @description	: 테스트결함관리 관련 처리를 담당하는 ServiceImpl
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Service("defServiceImpl")
+public class DefServiceImpl implements DefService {
+
+    @Resource(name="defDAO")
+    private DefDAO defDAO;
+	
+	@Resource(name = "messageSource")
+	private MessageSource messageSource;
+
+    /**
+     * 테스트결함관리 목록을 조회합니다.
+     *
+     * @process
+     * 1. 테스트결함관리 페이징 처리하여 목록을 조회한다.
+     * 2. 결과 List<DefVo>을(를) 리턴한다.
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 테스트결함관리 목록 List<DefVo>
+     * @throws Exception
+     */
+	public List<DefVo> selectListDef(DefVo defVo) throws Exception {
+		List<DefVo> list = defDAO.selectListDef(defVo);	
+	
+		return list;
+	}
+
+    /**
+     * 조회한 테스트결함관리 전체 카운트
+     *
+     * @process
+     * 1. 테스트결함관리 조회하여 전체 카운트를 리턴한다.
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 테스트결함관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountDef(DefVo defVo) throws Exception {
+		return defDAO.selectListCountDef(defVo);
+	}
+
+    /**
+     * 테스트결함관리를 상세 조회한다.
+     *
+     * @process
+     * 1. 테스트결함관리를 상세 조회한다.
+     * 2. 결과 DefVo을(를) 리턴한다.
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public DefVo selectDef(DefVo defVo) throws Exception {
+		DefVo resultVO = defDAO.selectDef(defVo);			
+        
+        return resultVO;
+	}
+
+    /**
+     * 테스트결함관리를 등록 처리 한다.
+     *
+     * @process
+     * 1. 테스트결함관리를 등록 처리 한다.
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertDef(DefVo defVo) throws Exception {
+		return defDAO.insertDef(defVo);	
+	}
+	
+    /**
+     * 테스트결함관리를 갱신 처리 한다.
+     *
+     * @process
+     * 1. 테스트결함관리를 갱신 처리 한다.
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateDef(DefVo defVo) throws Exception {				
+		return defDAO.updateDef(defVo);	   		
+	}
+
+    /**
+     * 테스트결함관리를 삭제 처리 한다.
+     *
+     * @process
+     * 1. 테스트결함관리를 삭제 처리 한다.
+     * 
+     * @param  defVo 테스트결함관리 DefVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteDef(DefVo defVo) throws Exception {
+		return defDAO.deleteDef(defVo);
+	}
+	
+}

--- a/src/main/java/com/demo/proworks/defect/vo/DefListVo.java
+++ b/src/main/java/com/demo/proworks/defect/vo/DefListVo.java
@@ -1,0 +1,32 @@
+package com.demo.proworks.defect.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", logicalName = "테스트결함관리")
+public class DefListVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    @ElDtoField(logicalName = "테스트결함관리List", physicalName = "defVoList", type = "com.demo.proworks.defect.DefVo", typeKind = "List", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private java.util.List<com.demo.proworks.defect.vo.DefVo> defVoList;
+
+    public java.util.List<com.demo.proworks.defect.vo.DefVo> getDefVoList(){
+        return defVoList;
+    }
+
+    public void setDefVoList(java.util.List<com.demo.proworks.defect.vo.DefVo> defVoList){
+        this.defVoList = defVoList;
+    }
+
+    @Override
+    public String toString() {
+        return "DefListVo [defVoList=" + defVoList+ "]";
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/demo/proworks/defect/vo/DefVo.java
+++ b/src/main/java/com/demo/proworks/defect/vo/DefVo.java
@@ -1,0 +1,249 @@
+package com.demo.proworks.defect.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.inswave.elfw.annotation.ElVoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", delimeterYn = "", logicalName = "테스트결함관리")
+public class DefVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    public DefVo(){
+    }
+
+    @ElDtoField(logicalName = "결함 고유 ID", physicalName = "id", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String id;
+
+    @ElDtoField(logicalName = "연결된 테스트 ID", physicalName = "testId", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String testId;
+
+    @ElDtoField(logicalName = "결함명", physicalName = "name", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String name;
+
+    @ElDtoField(logicalName = "결함 상세 설명", physicalName = "description", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String description;
+
+    @ElDtoField(logicalName = "우선순위 (Critical/High/Medium/Low)", physicalName = "priority", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String priority;
+
+    @ElDtoField(logicalName = "상태 (신규/진행중/수정완료/재오픈/종료)", physicalName = "status", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String status;
+
+    @ElDtoField(logicalName = "등록일시", physicalName = "createdAt", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String createdAt;
+
+    @ElDtoField(logicalName = "수정 담당자", physicalName = "assignee", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String assignee;
+
+    @ElDtoField(logicalName = "수정 기한", physicalName = "fixDueDate", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String fixDueDate;
+
+    @ElDtoField(logicalName = "수정 완료일", physicalName = "fixedDate", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String fixedDate;
+
+    @ElDtoField(logicalName = "비고사항", physicalName = "remarks", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String remarks;
+
+    @ElDtoField(logicalName = "삭제 여부", physicalName = "isDeleted", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String isDeleted;
+
+    @ElDtoField(logicalName = "테스트명", physicalName = "testName", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String testName;
+
+    @ElDtoField(logicalName = "사용자명", physicalName = "userName", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String userName;
+
+    @ElVoField(physicalName = "id")
+    public String getId(){
+        String ret = this.id;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "id")
+    public void setId(String id){
+        this.id = id;
+    }
+
+    @ElVoField(physicalName = "testId")
+    public String getTestId(){
+        String ret = this.testId;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "testId")
+    public void setTestId(String testId){
+        this.testId = testId;
+    }
+
+    @ElVoField(physicalName = "name")
+    public String getName(){
+        String ret = this.name;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "name")
+    public void setName(String name){
+        this.name = name;
+    }
+
+    @ElVoField(physicalName = "description")
+    public String getDescription(){
+        String ret = this.description;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "description")
+    public void setDescription(String description){
+        this.description = description;
+    }
+
+    @ElVoField(physicalName = "priority")
+    public String getPriority(){
+        String ret = this.priority;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "priority")
+    public void setPriority(String priority){
+        this.priority = priority;
+    }
+
+    @ElVoField(physicalName = "status")
+    public String getStatus(){
+        String ret = this.status;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "status")
+    public void setStatus(String status){
+        this.status = status;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public String getCreatedAt(){
+        String ret = this.createdAt;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public void setCreatedAt(String createdAt){
+        this.createdAt = createdAt;
+    }
+
+    @ElVoField(physicalName = "assignee")
+    public String getAssignee(){
+        String ret = this.assignee;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "assignee")
+    public void setAssignee(String assignee){
+        this.assignee = assignee;
+    }
+
+    @ElVoField(physicalName = "fixDueDate")
+    public String getFixDueDate(){
+        String ret = this.fixDueDate;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "fixDueDate")
+    public void setFixDueDate(String fixDueDate){
+        this.fixDueDate = fixDueDate;
+    }
+
+    @ElVoField(physicalName = "fixedDate")
+    public String getFixedDate(){
+        String ret = this.fixedDate;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "fixedDate")
+    public void setFixedDate(String fixedDate){
+        this.fixedDate = fixedDate;
+    }
+
+    @ElVoField(physicalName = "remarks")
+    public String getRemarks(){
+        String ret = this.remarks;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "remarks")
+    public void setRemarks(String remarks){
+        this.remarks = remarks;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public String getIsDeleted(){
+        String ret = this.isDeleted;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public void setIsDeleted(String isDeleted){
+        this.isDeleted = isDeleted;
+    }
+
+    @ElVoField(physicalName = "testName")
+    public String getTestName(){
+        String ret = this.testName;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "testName")
+    public void setTestName(String testName){
+        this.testName = testName;
+    }
+
+    @ElVoField(physicalName = "userName")
+    public String getUserName(){
+        String ret = this.userName;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "userName")
+    public void setUserName(String userName){
+        this.userName = userName;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DefVo [");
+        sb.append("id").append("=").append(id).append(",");
+        sb.append("testId").append("=").append(testId).append(",");
+        sb.append("name").append("=").append(name).append(",");
+        sb.append("description").append("=").append(description).append(",");
+        sb.append("priority").append("=").append(priority).append(",");
+        sb.append("status").append("=").append(status).append(",");
+        sb.append("createdAt").append("=").append(createdAt).append(",");
+        sb.append("assignee").append("=").append(assignee).append(",");
+        sb.append("fixDueDate").append("=").append(fixDueDate).append(",");
+        sb.append("fixedDate").append("=").append(fixedDate).append(",");
+        sb.append("remarks").append("=").append(remarks).append(",");
+        sb.append("isDeleted").append("=").append(isDeleted).append(",");
+        sb.append("testName").append("=").append(testName).append(",");
+        sb.append("userName").append("=").append(userName);
+        sb.append("]");
+        return sb.toString();
+
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+    @Override
+    public void _xStreamEnc() {
+    }
+
+
+    @Override
+    public void _xStreamDec() {
+    }
+
+
+}

--- a/src/main/java/com/demo/proworks/defect/web/DefController.java
+++ b/src/main/java/com/demo/proworks/defect/web/DefController.java
@@ -1,0 +1,119 @@
+package com.demo.proworks.defect.web;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.demo.proworks.defect.service.DefService;
+import com.demo.proworks.defect.vo.DefVo;
+import com.demo.proworks.defect.vo.DefListVo;
+
+import com.inswave.elfw.annotation.ElDescription;
+import com.inswave.elfw.annotation.ElService;
+import com.inswave.elfw.annotation.ElValidator;
+
+/**  
+ * @subject     : 테스트결함관리 관련 처리를 담당하는 컨트롤러
+ * @description : 테스트결함관리 관련 처리를 담당하는 컨트롤러
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Controller
+public class DefController {
+	
+    /** DefService */
+    @Resource(name = "defServiceImpl")
+    private DefService defService;
+	
+    
+    /**
+     * 테스트결함관리 목록을 조회합니다.
+     *
+     * @param  defVo 테스트결함관리
+     * @return 목록조회 결과
+     * @throws Exception
+     */
+    @ElService(key="DEF001List")
+    @RequestMapping(value="DEF001List")    
+    @ElDescription(sub="테스트결함관리 목록조회",desc="페이징을 처리하여 테스트결함관리 목록 조회를 한다.")               
+    public DefListVo selectListDef(DefVo defVo) throws Exception {    	   	
+
+        List<DefVo> defList = defService.selectListDef(defVo);                  
+        long totCnt = defService.selectListCountDef(defVo);
+	
+		DefListVo retDefList = new DefListVo();
+		retDefList.setDefVoList(defList); 
+		retDefList.setTotalCount(totCnt);
+		retDefList.setPageSize(defVo.getPageSize());
+		retDefList.setPageIndex(defVo.getPageIndex());
+
+        return retDefList;            
+    }  
+        
+    /**
+     * 테스트결함관리을 단건 조회 처리 한다.
+     *
+     * @param  defVo 테스트결함관리
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+    @ElService(key = "DEF001UpdView")    
+    @RequestMapping(value="DEF001UpdView") 
+    @ElDescription(sub = "테스트결함관리 갱신 폼을 위한 조회", desc = "테스트결함관리 갱신 폼을 위한 조회를 한다.")    
+    public DefVo selectDef(DefVo defVo) throws Exception {
+    	DefVo selectDefVo = defService.selectDef(defVo);    	    
+		
+        return selectDefVo;
+    } 
+ 
+    /**
+     * 테스트결함관리를 등록 처리 한다.
+     *
+     * @param  defVo 테스트결함관리
+     * @throws Exception
+     */
+    @ElService(key="DEF001Ins")    
+    @RequestMapping(value="DEF001Ins")
+    @ElDescription(sub="테스트결함관리 등록처리",desc="테스트결함관리를 등록 처리 한다.")
+    public void insertDef(DefVo defVo) throws Exception {    	 
+    	defService.insertDef(defVo);   
+    }
+       
+    /**
+     * 테스트결함관리를 갱신 처리 한다.
+     *
+     * @param  defVo 테스트결함관리
+     * @throws Exception
+     */
+    @ElService(key="DEF001Upd")    
+    @RequestMapping(value="DEF001Upd")    
+    @ElValidator(errUrl="/def/defRegister", errContinue=true)
+    @ElDescription(sub="테스트결함관리 갱신처리",desc="테스트결함관리를 갱신 처리 한다.")    
+    public void updateDef(DefVo defVo) throws Exception {  
+ 
+    	defService.updateDef(defVo);                                            
+    }
+
+    /**
+     * 테스트결함관리를 삭제 처리한다.
+     *
+     * @param  defVo 테스트결함관리    
+     * @throws Exception
+     */
+    @ElService(key = "DEF001Del")    
+    @RequestMapping(value="DEF001Del")
+    @ElDescription(sub = "테스트결함관리 삭제처리", desc = "테스트결함관리를 삭제 처리한다.")    
+    public void deleteDef(DefVo defVo) throws Exception {
+        defService.deleteDef(defVo);
+    }
+   
+}

--- a/src/main/java/com/demo/proworks/iss/dao/IssDAO.java
+++ b/src/main/java/com/demo/proworks/iss/dao/IssDAO.java
@@ -1,0 +1,92 @@
+package com.demo.proworks.iss.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.inswave.elfw.exception.ElException;
+import com.demo.proworks.iss.vo.IssVo;
+import com.demo.proworks.iss.dao.IssDAO;
+
+/**  
+ * @subject     : 이슈리스크관리 관련 처리를 담당하는 DAO
+ * @description : 이슈리스크관리 관련 처리를 담당하는 DAO
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Repository("issDAO")
+public class IssDAO extends com.demo.proworks.cmmn.dao.ProworksDefaultAbstractDAO {
+
+    /**
+     * 이슈리스크관리 상세 조회한다.
+     *  
+     * @param  IssVo 이슈리스크관리
+     * @return IssVo 이슈리스크관리
+     * @throws ElException
+     */
+    public IssVo selectIss(IssVo vo) throws ElException {
+        return (IssVo) selectByPk("com.demo.proworks.iss.selectIss", vo);
+    }
+
+    /**
+     * 페이징을 처리하여 이슈리스크관리 목록조회를 한다.
+     *  
+     * @param  IssVo 이슈리스크관리
+     * @return List<IssVo> 이슈리스크관리
+     * @throws ElException
+     */
+    public List<IssVo> selectListIss(IssVo vo) throws ElException {      	
+        return (List<IssVo>)list("com.demo.proworks.iss.selectListIss", vo);
+    }
+
+    /**
+     * 이슈리스크관리 목록 조회의 전체 카운트를 조회한다.
+     *  
+     * @param  IssVo 이슈리스크관리
+     * @return 이슈리스크관리 조회의 전체 카운트
+     * @throws ElException
+     */
+    public long selectListCountIss(IssVo vo)  throws ElException{               
+        return (Long)selectByPk("com.demo.proworks.iss.selectListCountIss", vo);
+    }
+        
+    /**
+     * 이슈리스크관리를 등록한다.
+     *  
+     * @param  IssVo 이슈리스크관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int insertIss(IssVo vo) throws ElException {    	
+        return insert("com.demo.proworks.iss.insertIss", vo);
+    }
+
+    /**
+     * 이슈리스크관리를 갱신한다.
+     *  
+     * @param  IssVo 이슈리스크관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int updateIss(IssVo vo) throws ElException {
+        return update("com.demo.proworks.iss.updateIss", vo);
+    }
+
+    /**
+     * 이슈리스크관리를 삭제한다.
+     *  
+     * @param  IssVo 이슈리스크관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int deleteIss(IssVo vo) throws ElException {
+        return delete("com.demo.proworks.iss.deleteIss", vo);
+    }
+
+}

--- a/src/main/java/com/demo/proworks/iss/service/IssService.java
+++ b/src/main/java/com/demo/proworks/iss/service/IssService.java
@@ -1,0 +1,75 @@
+package com.demo.proworks.iss.service;
+
+import java.util.List;
+
+import com.demo.proworks.iss.vo.IssVo;
+
+/**  
+ * @subject     : 이슈리스크관리 관련 처리를 담당하는 인터페이스
+ * @description : 이슈리스크관리 관련 처리를 담당하는 인터페이스
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+public interface IssService {
+	
+    /**
+     * 이슈리스크관리 페이징 처리하여 목록을 조회한다.
+     *
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 이슈리스크관리 목록 List<IssVo>
+     * @throws Exception
+     */
+	public List<IssVo> selectListIss(IssVo issVo) throws Exception;
+	
+    /**
+     * 조회한 이슈리스크관리 전체 카운트
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 이슈리스크관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountIss(IssVo issVo) throws Exception;
+	
+    /**
+     * 이슈리스크관리를 상세 조회한다.
+     *
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public IssVo selectIss(IssVo issVo) throws Exception;
+		
+    /**
+     * 이슈리스크관리를 등록 처리 한다.
+     *
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertIss(IssVo issVo) throws Exception;
+	
+    /**
+     * 이슈리스크관리를 갱신 처리 한다.
+     *
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateIss(IssVo issVo) throws Exception;
+	
+    /**
+     * 이슈리스크관리를 삭제 처리 한다.
+     *
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteIss(IssVo issVo) throws Exception;
+	
+}

--- a/src/main/java/com/demo/proworks/iss/service/impl/IssServiceImpl.java
+++ b/src/main/java/com/demo/proworks/iss/service/impl/IssServiceImpl.java
@@ -1,0 +1,125 @@
+package com.demo.proworks.iss.service.impl;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import com.demo.proworks.iss.service.IssService;
+import com.demo.proworks.iss.vo.IssVo;
+import com.demo.proworks.iss.dao.IssDAO;
+
+/**  
+ * @subject     : 이슈리스크관리 관련 처리를 담당하는 ServiceImpl
+ * @description	: 이슈리스크관리 관련 처리를 담당하는 ServiceImpl
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Service("issServiceImpl")
+public class IssServiceImpl implements IssService {
+
+    @Resource(name="issDAO")
+    private IssDAO issDAO;
+	
+	@Resource(name = "messageSource")
+	private MessageSource messageSource;
+
+    /**
+     * 이슈리스크관리 목록을 조회합니다.
+     *
+     * @process
+     * 1. 이슈리스크관리 페이징 처리하여 목록을 조회한다.
+     * 2. 결과 List<IssVo>을(를) 리턴한다.
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 이슈리스크관리 목록 List<IssVo>
+     * @throws Exception
+     */
+	public List<IssVo> selectListIss(IssVo issVo) throws Exception {
+		List<IssVo> list = issDAO.selectListIss(issVo);	
+	
+		return list;
+	}
+
+    /**
+     * 조회한 이슈리스크관리 전체 카운트
+     *
+     * @process
+     * 1. 이슈리스크관리 조회하여 전체 카운트를 리턴한다.
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 이슈리스크관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountIss(IssVo issVo) throws Exception {
+		return issDAO.selectListCountIss(issVo);
+	}
+
+    /**
+     * 이슈리스크관리를 상세 조회한다.
+     *
+     * @process
+     * 1. 이슈리스크관리를 상세 조회한다.
+     * 2. 결과 IssVo을(를) 리턴한다.
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public IssVo selectIss(IssVo issVo) throws Exception {
+		IssVo resultVO = issDAO.selectIss(issVo);			
+        
+        return resultVO;
+	}
+
+    /**
+     * 이슈리스크관리를 등록 처리 한다.
+     *
+     * @process
+     * 1. 이슈리스크관리를 등록 처리 한다.
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertIss(IssVo issVo) throws Exception {
+		return issDAO.insertIss(issVo);	
+	}
+	
+    /**
+     * 이슈리스크관리를 갱신 처리 한다.
+     *
+     * @process
+     * 1. 이슈리스크관리를 갱신 처리 한다.
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateIss(IssVo issVo) throws Exception {				
+		return issDAO.updateIss(issVo);	   		
+	}
+
+    /**
+     * 이슈리스크관리를 삭제 처리 한다.
+     *
+     * @process
+     * 1. 이슈리스크관리를 삭제 처리 한다.
+     * 
+     * @param  issVo 이슈리스크관리 IssVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteIss(IssVo issVo) throws Exception {
+		return issDAO.deleteIss(issVo);
+	}
+	
+}

--- a/src/main/java/com/demo/proworks/iss/vo/IssListVo.java
+++ b/src/main/java/com/demo/proworks/iss/vo/IssListVo.java
@@ -1,0 +1,32 @@
+package com.demo.proworks.iss.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", logicalName = "이슈리스크관리")
+public class IssListVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    @ElDtoField(logicalName = "이슈리스크관리List", physicalName = "issVoList", type = "com.demo.proworks.iss.IssVo", typeKind = "List", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private java.util.List<com.demo.proworks.iss.vo.IssVo> issVoList;
+
+    public java.util.List<com.demo.proworks.iss.vo.IssVo> getIssVoList(){
+        return issVoList;
+    }
+
+    public void setIssVoList(java.util.List<com.demo.proworks.iss.vo.IssVo> issVoList){
+        this.issVoList = issVoList;
+    }
+
+    @Override
+    public String toString() {
+        return "IssListVo [issVoList=" + issVoList+ "]";
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/demo/proworks/iss/vo/IssVo.java
+++ b/src/main/java/com/demo/proworks/iss/vo/IssVo.java
@@ -1,0 +1,204 @@
+package com.demo.proworks.iss.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.inswave.elfw.annotation.ElVoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", logicalName = "이슈리스크관리")
+public class IssVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    @ElDtoField(logicalName = "프로젝트 ID", physicalName = "pjtId", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String pjtId;
+
+    @ElDtoField(logicalName = "이슈/리스크 고유 ID", physicalName = "id", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String id;
+
+    @ElDtoField(logicalName = "이슈/리스크명", physicalName = "name", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String name;
+
+    @ElDtoField(logicalName = "작성자 사용자 ID", physicalName = "userId", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String userId;
+
+    @ElDtoField(logicalName = "완료 예정일", physicalName = "dueDate", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String dueDate;
+
+    @ElDtoField(logicalName = "상태 (해결 전, 해결 중, 해결 후)", physicalName = "status", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String status;
+
+    @ElDtoField(logicalName = "우선순위 (높음, 중간, 낮음)", physicalName = "priority", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String priority;
+
+    @ElDtoField(logicalName = "타입 (이슈, 리스크, 테스트)", physicalName = "type", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String type;
+
+    @ElDtoField(logicalName = "상세 내용", physicalName = "description", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String description;
+
+    @ElDtoField(logicalName = "등록일시", physicalName = "createdAt", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String createdAt;
+
+    @ElDtoField(logicalName = "수정일시", physicalName = "updatedAt", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String updatedAt;
+
+    @ElDtoField(logicalName = "resolved_date", physicalName = "resolvedDate", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String resolvedDate;
+
+    @ElDtoField(logicalName = "response_plan", physicalName = "responsePlan", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String responsePlan;
+
+    @ElDtoField(logicalName = "is_deleted", physicalName = "isDeleted", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String isDeleted;
+
+    @ElVoField(physicalName = "pjtId")
+    public String getPjtId(){
+        return pjtId;
+    }
+
+    @ElVoField(physicalName = "pjtId")
+    public void setPjtId(String pjtId){
+        this.pjtId = pjtId;
+    }
+
+    @ElVoField(physicalName = "id")
+    public String getId(){
+        return id;
+    }
+
+    @ElVoField(physicalName = "id")
+    public void setId(String id){
+        this.id = id;
+    }
+
+    @ElVoField(physicalName = "name")
+    public String getName(){
+        return name;
+    }
+
+    @ElVoField(physicalName = "name")
+    public void setName(String name){
+        this.name = name;
+    }
+
+    @ElVoField(physicalName = "userId")
+    public String getUserId(){
+        return userId;
+    }
+
+    @ElVoField(physicalName = "userId")
+    public void setUserId(String userId){
+        this.userId = userId;
+    }
+
+    @ElVoField(physicalName = "dueDate")
+    public String getDueDate(){
+        return dueDate;
+    }
+
+    @ElVoField(physicalName = "dueDate")
+    public void setDueDate(String dueDate){
+        this.dueDate = dueDate;
+    }
+
+    @ElVoField(physicalName = "status")
+    public String getStatus(){
+        return status;
+    }
+
+    @ElVoField(physicalName = "status")
+    public void setStatus(String status){
+        this.status = status;
+    }
+
+    @ElVoField(physicalName = "priority")
+    public String getPriority(){
+        return priority;
+    }
+
+    @ElVoField(physicalName = "priority")
+    public void setPriority(String priority){
+        this.priority = priority;
+    }
+
+    @ElVoField(physicalName = "type")
+    public String getType(){
+        return type;
+    }
+
+    @ElVoField(physicalName = "type")
+    public void setType(String type){
+        this.type = type;
+    }
+
+    @ElVoField(physicalName = "description")
+    public String getDescription(){
+        return description;
+    }
+
+    @ElVoField(physicalName = "description")
+    public void setDescription(String description){
+        this.description = description;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public String getCreatedAt(){
+        return createdAt;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public void setCreatedAt(String createdAt){
+        this.createdAt = createdAt;
+    }
+
+    @ElVoField(physicalName = "updatedAt")
+    public String getUpdatedAt(){
+        return updatedAt;
+    }
+
+    @ElVoField(physicalName = "updatedAt")
+    public void setUpdatedAt(String updatedAt){
+        this.updatedAt = updatedAt;
+    }
+
+    @ElVoField(physicalName = "resolvedDate")
+    public String getResolvedDate(){
+        return resolvedDate;
+    }
+
+    @ElVoField(physicalName = "resolvedDate")
+    public void setResolvedDate(String resolvedDate){
+        this.resolvedDate = resolvedDate;
+    }
+
+    @ElVoField(physicalName = "responsePlan")
+    public String getResponsePlan(){
+        return responsePlan;
+    }
+
+    @ElVoField(physicalName = "responsePlan")
+    public void setResponsePlan(String responsePlan){
+        this.responsePlan = responsePlan;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public String getIsDeleted(){
+        return isDeleted;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public void setIsDeleted(String isDeleted){
+        this.isDeleted = isDeleted;
+    }
+
+    @Override
+    public String toString() {
+        return "IssVo [pjtId=" + pjtId + ",id=" + id + ",name=" + name + ",userId=" + userId + ",dueDate=" + dueDate + ",status=" + status + ",priority=" + priority + ",type=" + type + ",description=" + description + ",createdAt=" + createdAt + ",updatedAt=" + updatedAt + ",resolvedDate=" + resolvedDate + ",responsePlan=" + responsePlan + ",isDeleted=" + isDeleted + "]";
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/demo/proworks/iss/web/IssController.java
+++ b/src/main/java/com/demo/proworks/iss/web/IssController.java
@@ -1,0 +1,119 @@
+package com.demo.proworks.iss.web;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.demo.proworks.iss.service.IssService;
+import com.demo.proworks.iss.vo.IssVo;
+import com.demo.proworks.iss.vo.IssListVo;
+
+import com.inswave.elfw.annotation.ElDescription;
+import com.inswave.elfw.annotation.ElService;
+import com.inswave.elfw.annotation.ElValidator;
+
+/**  
+ * @subject     : 이슈리스크관리 관련 처리를 담당하는 컨트롤러
+ * @description : 이슈리스크관리 관련 처리를 담당하는 컨트롤러
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Controller
+public class IssController {
+	
+    /** IssService */
+    @Resource(name = "issServiceImpl")
+    private IssService issService;
+	
+    
+    /**
+     * 이슈리스크관리 목록을 조회합니다.
+     *
+     * @param  issVo 이슈리스크관리
+     * @return 목록조회 결과
+     * @throws Exception
+     */
+    @ElService(key="ISS001List")
+    @RequestMapping(value="ISS001List")    
+    @ElDescription(sub="이슈리스크관리 목록조회",desc="페이징을 처리하여 이슈리스크관리 목록 조회를 한다.")               
+    public IssListVo selectListIss(IssVo issVo) throws Exception {    	   	
+
+        List<IssVo> issList = issService.selectListIss(issVo);                  
+        long totCnt = issService.selectListCountIss(issVo);
+	
+		IssListVo retIssList = new IssListVo();
+		retIssList.setIssVoList(issList); 
+		retIssList.setTotalCount(totCnt);
+		retIssList.setPageSize(issVo.getPageSize());
+		retIssList.setPageIndex(issVo.getPageIndex());
+
+        return retIssList;            
+    }  
+        
+    /**
+     * 이슈리스크관리을 단건 조회 처리 한다.
+     *
+     * @param  issVo 이슈리스크관리
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+    @ElService(key = "ISS001UpdView")    
+    @RequestMapping(value="ISS001UpdView") 
+    @ElDescription(sub = "이슈리스크관리 갱신 폼을 위한 조회", desc = "이슈리스크관리 갱신 폼을 위한 조회를 한다.")    
+    public IssVo selectIss(IssVo issVo) throws Exception {
+    	IssVo selectIssVo = issService.selectIss(issVo);    	    
+		
+        return selectIssVo;
+    } 
+ 
+    /**
+     * 이슈리스크관리를 등록 처리 한다.
+     *
+     * @param  issVo 이슈리스크관리
+     * @throws Exception
+     */
+    @ElService(key="ISS001Ins")    
+    @RequestMapping(value="ISS001Ins")
+    @ElDescription(sub="이슈리스크관리 등록처리",desc="이슈리스크관리를 등록 처리 한다.")
+    public void insertIss(IssVo issVo) throws Exception {    	 
+    	issService.insertIss(issVo);   
+    }
+       
+    /**
+     * 이슈리스크관리를 갱신 처리 한다.
+     *
+     * @param  issVo 이슈리스크관리
+     * @throws Exception
+     */
+    @ElService(key="ISS001Upd")    
+    @RequestMapping(value="ISS001Upd")    
+    @ElValidator(errUrl="/iss/issRegister", errContinue=true)
+    @ElDescription(sub="이슈리스크관리 갱신처리",desc="이슈리스크관리를 갱신 처리 한다.")    
+    public void updateIss(IssVo issVo) throws Exception {  
+ 
+    	issService.updateIss(issVo);                                            
+    }
+
+    /**
+     * 이슈리스크관리를 삭제 처리한다.
+     *
+     * @param  issVo 이슈리스크관리    
+     * @throws Exception
+     */
+    @ElService(key = "ISS001Del")    
+    @RequestMapping(value="ISS001Del")
+    @ElDescription(sub = "이슈리스크관리 삭제처리", desc = "이슈리스크관리를 삭제 처리한다.")    
+    public void deleteIss(IssVo issVo) throws Exception {
+        issService.deleteIss(issVo);
+    }
+   
+}

--- a/src/main/java/com/demo/proworks/out/dao/OutDAO.java
+++ b/src/main/java/com/demo/proworks/out/dao/OutDAO.java
@@ -1,0 +1,92 @@
+package com.demo.proworks.out.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.inswave.elfw.exception.ElException;
+import com.demo.proworks.out.vo.OutVo;
+import com.demo.proworks.out.dao.OutDAO;
+
+/**  
+ * @subject     : 산출물관리 관련 처리를 담당하는 DAO
+ * @description : 산출물관리 관련 처리를 담당하는 DAO
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Repository("outDAO")
+public class OutDAO extends com.demo.proworks.cmmn.dao.ProworksDefaultAbstractDAO {
+
+    /**
+     * 산출물관리 상세 조회한다.
+     *  
+     * @param  OutVo 산출물관리
+     * @return OutVo 산출물관리
+     * @throws ElException
+     */
+    public OutVo selectOut(OutVo vo) throws ElException {
+        return (OutVo) selectByPk("com.demo.proworks.out.selectOut", vo);
+    }
+
+    /**
+     * 페이징을 처리하여 산출물관리 목록조회를 한다.
+     *  
+     * @param  OutVo 산출물관리
+     * @return List<OutVo> 산출물관리
+     * @throws ElException
+     */
+    public List<OutVo> selectListOut(OutVo vo) throws ElException {      	
+        return (List<OutVo>)list("com.demo.proworks.out.selectListOut", vo);
+    }
+
+    /**
+     * 산출물관리 목록 조회의 전체 카운트를 조회한다.
+     *  
+     * @param  OutVo 산출물관리
+     * @return 산출물관리 조회의 전체 카운트
+     * @throws ElException
+     */
+    public long selectListCountOut(OutVo vo)  throws ElException{               
+        return (Long)selectByPk("com.demo.proworks.out.selectListCountOut", vo);
+    }
+        
+    /**
+     * 산출물관리를 등록한다.
+     *  
+     * @param  OutVo 산출물관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int insertOut(OutVo vo) throws ElException {    	
+        return insert("com.demo.proworks.out.insertOut", vo);
+    }
+
+    /**
+     * 산출물관리를 갱신한다.
+     *  
+     * @param  OutVo 산출물관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int updateOut(OutVo vo) throws ElException {
+        return update("com.demo.proworks.out.updateOut", vo);
+    }
+
+    /**
+     * 산출물관리를 삭제한다.
+     *  
+     * @param  OutVo 산출물관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int deleteOut(OutVo vo) throws ElException {
+        return delete("com.demo.proworks.out.deleteOut", vo);
+    }
+
+}

--- a/src/main/java/com/demo/proworks/out/service/OutService.java
+++ b/src/main/java/com/demo/proworks/out/service/OutService.java
@@ -1,0 +1,75 @@
+package com.demo.proworks.out.service;
+
+import java.util.List;
+
+import com.demo.proworks.out.vo.OutVo;
+
+/**  
+ * @subject     : 산출물관리 관련 처리를 담당하는 인터페이스
+ * @description : 산출물관리 관련 처리를 담당하는 인터페이스
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+public interface OutService {
+	
+    /**
+     * 산출물관리 페이징 처리하여 목록을 조회한다.
+     *
+     * @param  outVo 산출물관리 OutVo
+     * @return 산출물관리 목록 List<OutVo>
+     * @throws Exception
+     */
+	public List<OutVo> selectListOut(OutVo outVo) throws Exception;
+	
+    /**
+     * 조회한 산출물관리 전체 카운트
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 산출물관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountOut(OutVo outVo) throws Exception;
+	
+    /**
+     * 산출물관리를 상세 조회한다.
+     *
+     * @param  outVo 산출물관리 OutVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public OutVo selectOut(OutVo outVo) throws Exception;
+		
+    /**
+     * 산출물관리를 등록 처리 한다.
+     *
+     * @param  outVo 산출물관리 OutVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertOut(OutVo outVo) throws Exception;
+	
+    /**
+     * 산출물관리를 갱신 처리 한다.
+     *
+     * @param  outVo 산출물관리 OutVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateOut(OutVo outVo) throws Exception;
+	
+    /**
+     * 산출물관리를 삭제 처리 한다.
+     *
+     * @param  outVo 산출물관리 OutVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteOut(OutVo outVo) throws Exception;
+	
+}

--- a/src/main/java/com/demo/proworks/out/service/impl/OutServiceImpl.java
+++ b/src/main/java/com/demo/proworks/out/service/impl/OutServiceImpl.java
@@ -1,0 +1,125 @@
+package com.demo.proworks.out.service.impl;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import com.demo.proworks.out.service.OutService;
+import com.demo.proworks.out.vo.OutVo;
+import com.demo.proworks.out.dao.OutDAO;
+
+/**  
+ * @subject     : 산출물관리 관련 처리를 담당하는 ServiceImpl
+ * @description	: 산출물관리 관련 처리를 담당하는 ServiceImpl
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Service("outServiceImpl")
+public class OutServiceImpl implements OutService {
+
+    @Resource(name="outDAO")
+    private OutDAO outDAO;
+	
+	@Resource(name = "messageSource")
+	private MessageSource messageSource;
+
+    /**
+     * 산출물관리 목록을 조회합니다.
+     *
+     * @process
+     * 1. 산출물관리 페이징 처리하여 목록을 조회한다.
+     * 2. 결과 List<OutVo>을(를) 리턴한다.
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 산출물관리 목록 List<OutVo>
+     * @throws Exception
+     */
+	public List<OutVo> selectListOut(OutVo outVo) throws Exception {
+		List<OutVo> list = outDAO.selectListOut(outVo);	
+	
+		return list;
+	}
+
+    /**
+     * 조회한 산출물관리 전체 카운트
+     *
+     * @process
+     * 1. 산출물관리 조회하여 전체 카운트를 리턴한다.
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 산출물관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountOut(OutVo outVo) throws Exception {
+		return outDAO.selectListCountOut(outVo);
+	}
+
+    /**
+     * 산출물관리를 상세 조회한다.
+     *
+     * @process
+     * 1. 산출물관리를 상세 조회한다.
+     * 2. 결과 OutVo을(를) 리턴한다.
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public OutVo selectOut(OutVo outVo) throws Exception {
+		OutVo resultVO = outDAO.selectOut(outVo);			
+        
+        return resultVO;
+	}
+
+    /**
+     * 산출물관리를 등록 처리 한다.
+     *
+     * @process
+     * 1. 산출물관리를 등록 처리 한다.
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertOut(OutVo outVo) throws Exception {
+		return outDAO.insertOut(outVo);	
+	}
+	
+    /**
+     * 산출물관리를 갱신 처리 한다.
+     *
+     * @process
+     * 1. 산출물관리를 갱신 처리 한다.
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateOut(OutVo outVo) throws Exception {				
+		return outDAO.updateOut(outVo);	   		
+	}
+
+    /**
+     * 산출물관리를 삭제 처리 한다.
+     *
+     * @process
+     * 1. 산출물관리를 삭제 처리 한다.
+     * 
+     * @param  outVo 산출물관리 OutVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteOut(OutVo outVo) throws Exception {
+		return outDAO.deleteOut(outVo);
+	}
+	
+}

--- a/src/main/java/com/demo/proworks/out/vo/OutListVo.java
+++ b/src/main/java/com/demo/proworks/out/vo/OutListVo.java
@@ -1,0 +1,32 @@
+package com.demo.proworks.out.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", logicalName = "산출물관리")
+public class OutListVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    @ElDtoField(logicalName = "산출물관리List", physicalName = "outVoList", type = "com.demo.proworks.out.OutVo", typeKind = "List", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private java.util.List<com.demo.proworks.out.vo.OutVo> outVoList;
+
+    public java.util.List<com.demo.proworks.out.vo.OutVo> getOutVoList(){
+        return outVoList;
+    }
+
+    public void setOutVoList(java.util.List<com.demo.proworks.out.vo.OutVo> outVoList){
+        this.outVoList = outVoList;
+    }
+
+    @Override
+    public String toString() {
+        return "OutListVo [outVoList=" + outVoList+ "]";
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/demo/proworks/out/vo/OutVo.java
+++ b/src/main/java/com/demo/proworks/out/vo/OutVo.java
@@ -1,0 +1,152 @@
+package com.demo.proworks.out.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.inswave.elfw.annotation.ElVoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", logicalName = "산출물관리")
+public class OutVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    @ElDtoField(logicalName = "산출물 고유 ID", physicalName = "id", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String id;
+
+    @ElDtoField(logicalName = "프로젝트 ID", physicalName = "pjtId", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String pjtId;
+
+    @ElDtoField(logicalName = "산출물명", physicalName = "name", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String name;
+
+    @ElDtoField(logicalName = "등록일시", physicalName = "createdAt", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String createdAt;
+
+    @ElDtoField(logicalName = "수정일시", physicalName = "updatedAt", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String updatedAt;
+
+    @ElDtoField(logicalName = "승인 상태 (대기/승인/반려)", physicalName = "approvalStatus", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String approvalStatus;
+
+    @ElDtoField(logicalName = "승인일시", physicalName = "approvalDate", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String approvalDate;
+
+    @ElDtoField(logicalName = "승인/반려 의견", physicalName = "approvalComment", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String approvalComment;
+
+    @ElDtoField(logicalName = "산출물 유형", physicalName = "outputType", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String outputType;
+
+    @ElDtoField(logicalName = "삭제 여부", physicalName = "isDeleted", type = "String", typeKind = "", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private String isDeleted;
+
+    @ElVoField(physicalName = "id")
+    public String getId(){
+        return id;
+    }
+
+    @ElVoField(physicalName = "id")
+    public void setId(String id){
+        this.id = id;
+    }
+
+    @ElVoField(physicalName = "pjtId")
+    public String getPjtId(){
+        return pjtId;
+    }
+
+    @ElVoField(physicalName = "pjtId")
+    public void setPjtId(String pjtId){
+        this.pjtId = pjtId;
+    }
+
+    @ElVoField(physicalName = "name")
+    public String getName(){
+        return name;
+    }
+
+    @ElVoField(physicalName = "name")
+    public void setName(String name){
+        this.name = name;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public String getCreatedAt(){
+        return createdAt;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public void setCreatedAt(String createdAt){
+        this.createdAt = createdAt;
+    }
+
+    @ElVoField(physicalName = "updatedAt")
+    public String getUpdatedAt(){
+        return updatedAt;
+    }
+
+    @ElVoField(physicalName = "updatedAt")
+    public void setUpdatedAt(String updatedAt){
+        this.updatedAt = updatedAt;
+    }
+
+    @ElVoField(physicalName = "approvalStatus")
+    public String getApprovalStatus(){
+        return approvalStatus;
+    }
+
+    @ElVoField(physicalName = "approvalStatus")
+    public void setApprovalStatus(String approvalStatus){
+        this.approvalStatus = approvalStatus;
+    }
+
+    @ElVoField(physicalName = "approvalDate")
+    public String getApprovalDate(){
+        return approvalDate;
+    }
+
+    @ElVoField(physicalName = "approvalDate")
+    public void setApprovalDate(String approvalDate){
+        this.approvalDate = approvalDate;
+    }
+
+    @ElVoField(physicalName = "approvalComment")
+    public String getApprovalComment(){
+        return approvalComment;
+    }
+
+    @ElVoField(physicalName = "approvalComment")
+    public void setApprovalComment(String approvalComment){
+        this.approvalComment = approvalComment;
+    }
+
+    @ElVoField(physicalName = "outputType")
+    public String getOutputType(){
+        return outputType;
+    }
+
+    @ElVoField(physicalName = "outputType")
+    public void setOutputType(String outputType){
+        this.outputType = outputType;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public String getIsDeleted(){
+        return isDeleted;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public void setIsDeleted(String isDeleted){
+        this.isDeleted = isDeleted;
+    }
+
+    @Override
+    public String toString() {
+        return "OutVo [id=" + id + ",pjtId=" + pjtId + ",name=" + name + ",createdAt=" + createdAt + ",updatedAt=" + updatedAt + ",approvalStatus=" + approvalStatus + ",approvalDate=" + approvalDate + ",approvalComment=" + approvalComment + ",outputType=" + outputType + ",isDeleted=" + isDeleted + "]";
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/demo/proworks/out/web/OutController.java
+++ b/src/main/java/com/demo/proworks/out/web/OutController.java
@@ -1,0 +1,119 @@
+package com.demo.proworks.out.web;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.demo.proworks.out.service.OutService;
+import com.demo.proworks.out.vo.OutVo;
+import com.demo.proworks.out.vo.OutListVo;
+
+import com.inswave.elfw.annotation.ElDescription;
+import com.inswave.elfw.annotation.ElService;
+import com.inswave.elfw.annotation.ElValidator;
+
+/**  
+ * @subject     : 산출물관리 관련 처리를 담당하는 컨트롤러
+ * @description : 산출물관리 관련 처리를 담당하는 컨트롤러
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Controller
+public class OutController {
+	
+    /** OutService */
+    @Resource(name = "outServiceImpl")
+    private OutService outService;
+	
+    
+    /**
+     * 산출물관리 목록을 조회합니다.
+     *
+     * @param  outVo 산출물관리
+     * @return 목록조회 결과
+     * @throws Exception
+     */
+    @ElService(key="OUT001List")
+    @RequestMapping(value="OUT001List")    
+    @ElDescription(sub="산출물관리 목록조회",desc="페이징을 처리하여 산출물관리 목록 조회를 한다.")               
+    public OutListVo selectListOut(OutVo outVo) throws Exception {    	   	
+
+        List<OutVo> outList = outService.selectListOut(outVo);                  
+        long totCnt = outService.selectListCountOut(outVo);
+	
+		OutListVo retOutList = new OutListVo();
+		retOutList.setOutVoList(outList); 
+		retOutList.setTotalCount(totCnt);
+		retOutList.setPageSize(outVo.getPageSize());
+		retOutList.setPageIndex(outVo.getPageIndex());
+
+        return retOutList;            
+    }  
+        
+    /**
+     * 산출물관리을 단건 조회 처리 한다.
+     *
+     * @param  outVo 산출물관리
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+    @ElService(key = "OUT001UpdView")    
+    @RequestMapping(value="OUT001UpdView") 
+    @ElDescription(sub = "산출물관리 갱신 폼을 위한 조회", desc = "산출물관리 갱신 폼을 위한 조회를 한다.")    
+    public OutVo selectOut(OutVo outVo) throws Exception {
+    	OutVo selectOutVo = outService.selectOut(outVo);    	    
+		
+        return selectOutVo;
+    } 
+ 
+    /**
+     * 산출물관리를 등록 처리 한다.
+     *
+     * @param  outVo 산출물관리
+     * @throws Exception
+     */
+    @ElService(key="OUT001Ins")    
+    @RequestMapping(value="OUT001Ins")
+    @ElDescription(sub="산출물관리 등록처리",desc="산출물관리를 등록 처리 한다.")
+    public void insertOut(OutVo outVo) throws Exception {    	 
+    	outService.insertOut(outVo);   
+    }
+       
+    /**
+     * 산출물관리를 갱신 처리 한다.
+     *
+     * @param  outVo 산출물관리
+     * @throws Exception
+     */
+    @ElService(key="OUT001Upd")    
+    @RequestMapping(value="OUT001Upd")    
+    @ElValidator(errUrl="/out/outRegister", errContinue=true)
+    @ElDescription(sub="산출물관리 갱신처리",desc="산출물관리를 갱신 처리 한다.")    
+    public void updateOut(OutVo outVo) throws Exception {  
+ 
+    	outService.updateOut(outVo);                                            
+    }
+
+    /**
+     * 산출물관리를 삭제 처리한다.
+     *
+     * @param  outVo 산출물관리    
+     * @throws Exception
+     */
+    @ElService(key = "OUT001Del")    
+    @RequestMapping(value="OUT001Del")
+    @ElDescription(sub = "산출물관리 삭제처리", desc = "산출물관리를 삭제 처리한다.")    
+    public void deleteOut(OutVo outVo) throws Exception {
+        outService.deleteOut(outVo);
+    }
+   
+}

--- a/src/main/java/com/demo/proworks/test/dao/TestDAO.java
+++ b/src/main/java/com/demo/proworks/test/dao/TestDAO.java
@@ -1,0 +1,92 @@
+package com.demo.proworks.test.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.inswave.elfw.exception.ElException;
+import com.demo.proworks.test.vo.TestVo;
+import com.demo.proworks.test.dao.TestDAO;
+
+/**  
+ * @subject     : 테스트관리 관련 처리를 담당하는 DAO
+ * @description : 테스트관리 관련 처리를 담당하는 DAO
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Repository("testDAO")
+public class TestDAO extends com.demo.proworks.cmmn.dao.ProworksDefaultAbstractDAO {
+
+    /**
+     * 테스트관리 상세 조회한다.
+     *  
+     * @param  TestVo 테스트관리
+     * @return TestVo 테스트관리
+     * @throws ElException
+     */
+    public TestVo selectTest(TestVo vo) throws ElException {
+        return (TestVo) selectByPk("com.demo.proworks.test.selectTest", vo);
+    }
+
+    /**
+     * 페이징을 처리하여 테스트관리 목록조회를 한다.
+     *  
+     * @param  TestVo 테스트관리
+     * @return List<TestVo> 테스트관리
+     * @throws ElException
+     */
+    public List<TestVo> selectListTest(TestVo vo) throws ElException {      	
+        return (List<TestVo>)list("com.demo.proworks.test.selectListTest", vo);
+    }
+
+    /**
+     * 테스트관리 목록 조회의 전체 카운트를 조회한다.
+     *  
+     * @param  TestVo 테스트관리
+     * @return 테스트관리 조회의 전체 카운트
+     * @throws ElException
+     */
+    public long selectListCountTest(TestVo vo)  throws ElException{               
+        return (Long)selectByPk("com.demo.proworks.test.selectListCountTest", vo);
+    }
+        
+    /**
+     * 테스트관리를 등록한다.
+     *  
+     * @param  TestVo 테스트관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int insertTest(TestVo vo) throws ElException {    	
+        return insert("com.demo.proworks.test.insertTest", vo);
+    }
+
+    /**
+     * 테스트관리를 갱신한다.
+     *  
+     * @param  TestVo 테스트관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int updateTest(TestVo vo) throws ElException {
+        return update("com.demo.proworks.test.updateTest", vo);
+    }
+
+    /**
+     * 테스트관리를 삭제한다.
+     *  
+     * @param  TestVo 테스트관리
+     * @return 번호
+     * @throws ElException
+     */
+    public int deleteTest(TestVo vo) throws ElException {
+        return delete("com.demo.proworks.test.deleteTest", vo);
+    }
+
+}

--- a/src/main/java/com/demo/proworks/test/service/TestService.java
+++ b/src/main/java/com/demo/proworks/test/service/TestService.java
@@ -1,0 +1,75 @@
+package com.demo.proworks.test.service;
+
+import java.util.List;
+
+import com.demo.proworks.test.vo.TestVo;
+
+/**  
+ * @subject     : 테스트관리 관련 처리를 담당하는 인터페이스
+ * @description : 테스트관리 관련 처리를 담당하는 인터페이스
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+public interface TestService {
+	
+    /**
+     * 테스트관리 페이징 처리하여 목록을 조회한다.
+     *
+     * @param  testVo 테스트관리 TestVo
+     * @return 테스트관리 목록 List<TestVo>
+     * @throws Exception
+     */
+	public List<TestVo> selectListTest(TestVo testVo) throws Exception;
+	
+    /**
+     * 조회한 테스트관리 전체 카운트
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 테스트관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountTest(TestVo testVo) throws Exception;
+	
+    /**
+     * 테스트관리를 상세 조회한다.
+     *
+     * @param  testVo 테스트관리 TestVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public TestVo selectTest(TestVo testVo) throws Exception;
+		
+    /**
+     * 테스트관리를 등록 처리 한다.
+     *
+     * @param  testVo 테스트관리 TestVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertTest(TestVo testVo) throws Exception;
+	
+    /**
+     * 테스트관리를 갱신 처리 한다.
+     *
+     * @param  testVo 테스트관리 TestVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateTest(TestVo testVo) throws Exception;
+	
+    /**
+     * 테스트관리를 삭제 처리 한다.
+     *
+     * @param  testVo 테스트관리 TestVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteTest(TestVo testVo) throws Exception;
+	
+}

--- a/src/main/java/com/demo/proworks/test/service/impl/TestServiceImpl.java
+++ b/src/main/java/com/demo/proworks/test/service/impl/TestServiceImpl.java
@@ -1,0 +1,125 @@
+package com.demo.proworks.test.service.impl;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import com.demo.proworks.test.service.TestService;
+import com.demo.proworks.test.vo.TestVo;
+import com.demo.proworks.test.dao.TestDAO;
+
+/**  
+ * @subject     : 테스트관리 관련 처리를 담당하는 ServiceImpl
+ * @description	: 테스트관리 관련 처리를 담당하는 ServiceImpl
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Service("testServiceImpl")
+public class TestServiceImpl implements TestService {
+
+    @Resource(name="testDAO")
+    private TestDAO testDAO;
+	
+	@Resource(name = "messageSource")
+	private MessageSource messageSource;
+
+    /**
+     * 테스트관리 목록을 조회합니다.
+     *
+     * @process
+     * 1. 테스트관리 페이징 처리하여 목록을 조회한다.
+     * 2. 결과 List<TestVo>을(를) 리턴한다.
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 테스트관리 목록 List<TestVo>
+     * @throws Exception
+     */
+	public List<TestVo> selectListTest(TestVo testVo) throws Exception {
+		List<TestVo> list = testDAO.selectListTest(testVo);	
+	
+		return list;
+	}
+
+    /**
+     * 조회한 테스트관리 전체 카운트
+     *
+     * @process
+     * 1. 테스트관리 조회하여 전체 카운트를 리턴한다.
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 테스트관리 목록 전체 카운트
+     * @throws Exception
+     */
+	public long selectListCountTest(TestVo testVo) throws Exception {
+		return testDAO.selectListCountTest(testVo);
+	}
+
+    /**
+     * 테스트관리를 상세 조회한다.
+     *
+     * @process
+     * 1. 테스트관리를 상세 조회한다.
+     * 2. 결과 TestVo을(를) 리턴한다.
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+	public TestVo selectTest(TestVo testVo) throws Exception {
+		TestVo resultVO = testDAO.selectTest(testVo);			
+        
+        return resultVO;
+	}
+
+    /**
+     * 테스트관리를 등록 처리 한다.
+     *
+     * @process
+     * 1. 테스트관리를 등록 처리 한다.
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int insertTest(TestVo testVo) throws Exception {
+		return testDAO.insertTest(testVo);	
+	}
+	
+    /**
+     * 테스트관리를 갱신 처리 한다.
+     *
+     * @process
+     * 1. 테스트관리를 갱신 처리 한다.
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int updateTest(TestVo testVo) throws Exception {				
+		return testDAO.updateTest(testVo);	   		
+	}
+
+    /**
+     * 테스트관리를 삭제 처리 한다.
+     *
+     * @process
+     * 1. 테스트관리를 삭제 처리 한다.
+     * 
+     * @param  testVo 테스트관리 TestVo
+     * @return 번호
+     * @throws Exception
+     */
+	public int deleteTest(TestVo testVo) throws Exception {
+		return testDAO.deleteTest(testVo);
+	}
+	
+}

--- a/src/main/java/com/demo/proworks/test/vo/TestListVo.java
+++ b/src/main/java/com/demo/proworks/test/vo/TestListVo.java
@@ -1,0 +1,32 @@
+package com.demo.proworks.test.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", logicalName = "테스트관리")
+public class TestListVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    @ElDtoField(logicalName = "테스트관리List", physicalName = "testVoList", type = "com.demo.proworks.test.TestVo", typeKind = "List", fldYn = "", length = 0, dotLen = 0, baseValue = "", desc = "")
+    private java.util.List<com.demo.proworks.test.vo.TestVo> testVoList;
+
+    public java.util.List<com.demo.proworks.test.vo.TestVo> getTestVoList(){
+        return testVoList;
+    }
+
+    public void setTestVoList(java.util.List<com.demo.proworks.test.vo.TestVo> testVoList){
+        this.testVoList = testVoList;
+    }
+
+    @Override
+    public String toString() {
+        return "TestListVo [testVoList=" + testVoList+ "]";
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+}

--- a/src/main/java/com/demo/proworks/test/vo/TestVo.java
+++ b/src/main/java/com/demo/proworks/test/vo/TestVo.java
@@ -1,0 +1,294 @@
+package com.demo.proworks.test.vo;
+
+import com.inswave.elfw.annotation.ElDto;
+import com.inswave.elfw.annotation.ElDtoField;
+import com.inswave.elfw.annotation.ElVoField;
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+@JsonFilter("elExcludeFilter")
+@ElDto(FldYn = "", delimeterYn = "", logicalName = "테스트관리")
+public class TestVo extends com.demo.proworks.cmmn.ProworksCommVO {
+    private static final long serialVersionUID = 1L;
+
+    public TestVo(){
+    }
+
+    @ElDtoField(logicalName = "테스트 고유 ID", physicalName = "id", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String id;
+
+    @ElDtoField(logicalName = "연결된 업무 ID", physicalName = "taskId", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String taskId;
+
+    @ElDtoField(logicalName = "테스트 케이스명", physicalName = "name", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String name;
+
+    @ElDtoField(logicalName = "테스트 카테고리", physicalName = "category", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String category;
+
+    @ElDtoField(logicalName = "테스트 실행 시나리오", physicalName = "scenario", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String scenario;
+
+    @ElDtoField(logicalName = "테스트 입력 데이터", physicalName = "inputData", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String inputData;
+
+    @ElDtoField(logicalName = "예상 결과", physicalName = "expectedResult", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String expectedResult;
+
+    @ElDtoField(logicalName = "실제 결과", physicalName = "actualResult", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String actualResult;
+
+    @ElDtoField(logicalName = "테스트 결과", physicalName = "testResult", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String testResult;
+
+    @ElDtoField(logicalName = "테스트 담당자", physicalName = "assignee", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String assignee;
+
+    @ElDtoField(logicalName = "테스트 실행일", physicalName = "executionDate", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String executionDate;
+
+    @ElDtoField(logicalName = "테스트 소요시간(분)", physicalName = "duration", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String duration;
+
+    @ElDtoField(logicalName = "삭제 여부", physicalName = "isDeleted", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String isDeleted;
+
+    @ElDtoField(logicalName = "등록일시", physicalName = "createdAt", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String createdAt;
+
+    @ElDtoField(logicalName = "수정일시", physicalName = "updatedAt", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String updatedAt;
+
+    @ElDtoField(logicalName = "연결된 업무명", physicalName = "taskName", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String taskName;
+
+    @ElDtoField(logicalName = "담당자명", physicalName = "userName", type = "String", typeKind = "", fldYn = "", delimeterYn = "", cryptoGbn = "", cryptoKind = "", length = 0, dotLen = 0, baseValue = "", desc = "", attr = "")
+    private String userName;
+
+    @ElVoField(physicalName = "id")
+    public String getId(){
+        String ret = this.id;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "id")
+    public void setId(String id){
+        this.id = id;
+    }
+
+    @ElVoField(physicalName = "taskId")
+    public String getTaskId(){
+        String ret = this.taskId;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "taskId")
+    public void setTaskId(String taskId){
+        this.taskId = taskId;
+    }
+
+    @ElVoField(physicalName = "name")
+    public String getName(){
+        String ret = this.name;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "name")
+    public void setName(String name){
+        this.name = name;
+    }
+
+    @ElVoField(physicalName = "category")
+    public String getCategory(){
+        String ret = this.category;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "category")
+    public void setCategory(String category){
+        this.category = category;
+    }
+
+    @ElVoField(physicalName = "scenario")
+    public String getScenario(){
+        String ret = this.scenario;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "scenario")
+    public void setScenario(String scenario){
+        this.scenario = scenario;
+    }
+
+    @ElVoField(physicalName = "inputData")
+    public String getInputData(){
+        String ret = this.inputData;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "inputData")
+    public void setInputData(String inputData){
+        this.inputData = inputData;
+    }
+
+    @ElVoField(physicalName = "expectedResult")
+    public String getExpectedResult(){
+        String ret = this.expectedResult;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "expectedResult")
+    public void setExpectedResult(String expectedResult){
+        this.expectedResult = expectedResult;
+    }
+
+    @ElVoField(physicalName = "actualResult")
+    public String getActualResult(){
+        String ret = this.actualResult;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "actualResult")
+    public void setActualResult(String actualResult){
+        this.actualResult = actualResult;
+    }
+
+    @ElVoField(physicalName = "testResult")
+    public String getTestResult(){
+        String ret = this.testResult;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "testResult")
+    public void setTestResult(String testResult){
+        this.testResult = testResult;
+    }
+
+    @ElVoField(physicalName = "assignee")
+    public String getAssignee(){
+        String ret = this.assignee;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "assignee")
+    public void setAssignee(String assignee){
+        this.assignee = assignee;
+    }
+
+    @ElVoField(physicalName = "executionDate")
+    public String getExecutionDate(){
+        String ret = this.executionDate;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "executionDate")
+    public void setExecutionDate(String executionDate){
+        this.executionDate = executionDate;
+    }
+
+    @ElVoField(physicalName = "duration")
+    public String getDuration(){
+        String ret = this.duration;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "duration")
+    public void setDuration(String duration){
+        this.duration = duration;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public String getIsDeleted(){
+        String ret = this.isDeleted;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "isDeleted")
+    public void setIsDeleted(String isDeleted){
+        this.isDeleted = isDeleted;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public String getCreatedAt(){
+        String ret = this.createdAt;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "createdAt")
+    public void setCreatedAt(String createdAt){
+        this.createdAt = createdAt;
+    }
+
+    @ElVoField(physicalName = "updatedAt")
+    public String getUpdatedAt(){
+        String ret = this.updatedAt;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "updatedAt")
+    public void setUpdatedAt(String updatedAt){
+        this.updatedAt = updatedAt;
+    }
+
+    @ElVoField(physicalName = "taskName")
+    public String getTaskName(){
+        String ret = this.taskName;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "taskName")
+    public void setTaskName(String taskName){
+        this.taskName = taskName;
+    }
+
+    @ElVoField(physicalName = "userName")
+    public String getUserName(){
+        String ret = this.userName;
+        return ret;
+    }
+
+    @ElVoField(physicalName = "userName")
+    public void setUserName(String userName){
+        this.userName = userName;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("TestVo [");
+        sb.append("id").append("=").append(id).append(",");
+        sb.append("taskId").append("=").append(taskId).append(",");
+        sb.append("name").append("=").append(name).append(",");
+        sb.append("category").append("=").append(category).append(",");
+        sb.append("scenario").append("=").append(scenario).append(",");
+        sb.append("inputData").append("=").append(inputData).append(",");
+        sb.append("expectedResult").append("=").append(expectedResult).append(",");
+        sb.append("actualResult").append("=").append(actualResult).append(",");
+        sb.append("testResult").append("=").append(testResult).append(",");
+        sb.append("assignee").append("=").append(assignee).append(",");
+        sb.append("executionDate").append("=").append(executionDate).append(",");
+        sb.append("duration").append("=").append(duration).append(",");
+        sb.append("isDeleted").append("=").append(isDeleted).append(",");
+        sb.append("createdAt").append("=").append(createdAt).append(",");
+        sb.append("updatedAt").append("=").append(updatedAt).append(",");
+        sb.append("taskName").append("=").append(taskName).append(",");
+        sb.append("userName").append("=").append(userName);
+        sb.append("]");
+        return sb.toString();
+
+    }
+
+    public boolean isFixedLengthVo() {
+        return false;
+    }
+
+    @Override
+    public void _xStreamEnc() {
+    }
+
+
+    @Override
+    public void _xStreamDec() {
+    }
+
+
+}

--- a/src/main/java/com/demo/proworks/test/web/TestController.java
+++ b/src/main/java/com/demo/proworks/test/web/TestController.java
@@ -1,0 +1,119 @@
+package com.demo.proworks.test.web;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.demo.proworks.test.service.TestService;
+import com.demo.proworks.test.vo.TestVo;
+import com.demo.proworks.test.vo.TestListVo;
+
+import com.inswave.elfw.annotation.ElDescription;
+import com.inswave.elfw.annotation.ElService;
+import com.inswave.elfw.annotation.ElValidator;
+
+/**  
+ * @subject     : 테스트관리 관련 처리를 담당하는 컨트롤러
+ * @description : 테스트관리 관련 처리를 담당하는 컨트롤러
+ * @author      : 우민지
+ * @since       : 2025/07/07
+ * @modification
+ * ===========================================================
+ * DATE				AUTHOR				DESC
+ * ===========================================================
+ * 2025/07/07			 우민지	 		최초 생성
+ * 
+ */
+@Controller
+public class TestController {
+	
+    /** TestService */
+    @Resource(name = "testServiceImpl")
+    private TestService testService;
+	
+    
+    /**
+     * 테스트관리 목록을 조회합니다.
+     *
+     * @param  testVo 테스트관리
+     * @return 목록조회 결과
+     * @throws Exception
+     */
+    @ElService(key="TEST001List")
+    @RequestMapping(value="TEST001List")    
+    @ElDescription(sub="테스트관리 목록조회",desc="페이징을 처리하여 테스트관리 목록 조회를 한다.")               
+    public TestListVo selectListTest(TestVo testVo) throws Exception {    	   	
+
+        List<TestVo> testList = testService.selectListTest(testVo);                  
+        long totCnt = testService.selectListCountTest(testVo);
+	
+		TestListVo retTestList = new TestListVo();
+		retTestList.setTestVoList(testList); 
+		retTestList.setTotalCount(totCnt);
+		retTestList.setPageSize(testVo.getPageSize());
+		retTestList.setPageIndex(testVo.getPageIndex());
+
+        return retTestList;            
+    }  
+        
+    /**
+     * 테스트관리을 단건 조회 처리 한다.
+     *
+     * @param  testVo 테스트관리
+     * @return 단건 조회 결과
+     * @throws Exception
+     */
+    @ElService(key = "TEST001UpdView")    
+    @RequestMapping(value="TEST001UpdView") 
+    @ElDescription(sub = "테스트관리 갱신 폼을 위한 조회", desc = "테스트관리 갱신 폼을 위한 조회를 한다.")    
+    public TestVo selectTest(TestVo testVo) throws Exception {
+    	TestVo selectTestVo = testService.selectTest(testVo);    	    
+		
+        return selectTestVo;
+    } 
+ 
+    /**
+     * 테스트관리를 등록 처리 한다.
+     *
+     * @param  testVo 테스트관리
+     * @throws Exception
+     */
+    @ElService(key="TEST001Ins")    
+    @RequestMapping(value="TEST001Ins")
+    @ElDescription(sub="테스트관리 등록처리",desc="테스트관리를 등록 처리 한다.")
+    public void insertTest(TestVo testVo) throws Exception {    	 
+    	testService.insertTest(testVo);   
+    }
+       
+    /**
+     * 테스트관리를 갱신 처리 한다.
+     *
+     * @param  testVo 테스트관리
+     * @throws Exception
+     */
+    @ElService(key="TEST001Upd")    
+    @RequestMapping(value="TEST001Upd")    
+    @ElValidator(errUrl="/test/testRegister", errContinue=true)
+    @ElDescription(sub="테스트관리 갱신처리",desc="테스트관리를 갱신 처리 한다.")    
+    public void updateTest(TestVo testVo) throws Exception {  
+ 
+    	testService.updateTest(testVo);                                            
+    }
+
+    /**
+     * 테스트관리를 삭제 처리한다.
+     *
+     * @param  testVo 테스트관리    
+     * @throws Exception
+     */
+    @ElService(key = "TEST001Del")    
+    @RequestMapping(value="TEST001Del")
+    @ElDescription(sub = "테스트관리 삭제처리", desc = "테스트관리를 삭제 처리한다.")    
+    public void deleteTest(TestVo testVo) throws Exception {
+        testService.deleteTest(testVo);
+    }
+   
+}

--- a/src/main/resources/inswave/sqlmap/com/demo/proworks/defect/defect_SQL_mariadb_MyBatis.xml
+++ b/src/main/resources/inswave/sqlmap/com/demo/proworks/defect/defect_SQL_mariadb_MyBatis.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper      
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"      
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+	@subject     : 테스트결함관리 관련 처리를 담당하는 Sql Mapper
+	@description : 테스트결함관리 관련 처리를 담당하는 Sql Mapper
+	@author      : 우민지
+	@since       : 2025/07/07
+	@modification
+	===========================================================
+	DATE              AUTHOR             DESC
+	===========================================================
+	2025/07/07              우민지             최초 생성
+ -->
+<mapper namespace="com.demo.proworks.defect">
+    <insert id="insertDef" parameterType="com.demo.proworks.defect.vo.DefVo">
+    	<!-- 테스트결함관리를 등록한다. -->	
+    		
+        INSERT INTO DEFECT   /* QueryID : com.demo.proworks.defect.insertDef */
+        ( 
+            ID
+            <if test="testId     != null"> , TEST_ID      </if>
+            <if test="name        != null"> , NAME         </if>
+            <if test="description != null"> , DESCRIPTION  </if>
+            <if test="priority    != null"> , PRIORITY     </if>
+            <if test="status      != null"> , STATUS       </if>
+            <if test="createdAt  != null"> , CREATED_AT   </if>
+            <if test="assignee    != null"> , ASSIGNEE     </if>
+            <if test="fixDueDate!= null"> , FIX_DUE_DATE </if>
+            <if test="fixedDate  != null"> , FIXED_DATE   </if>
+            <if test="remarks     != null"> , REMARKS      </if>
+            <if test="isDeleted  != null"> , IS_DELETED   </if>
+        )
+        VALUES  
+        ( 
+            #{id}
+            <if test="testId     != null"> , #{testId}      </if>
+            <if test="name        != null"> , #{name}         </if>
+            <if test="description != null"> , #{description}  </if>
+            <if test="priority    != null"> , #{priority}     </if>
+            <if test="status      != null"> , #{status}       </if>
+            <if test="createdAt  != null"> , #{createdAt}   </if>
+            <if test="assignee    != null"> , #{assignee}     </if>
+            <if test="fixDueDate!= null"> , #{fixDueDate} </if>
+            <if test="fixedDate  != null"> , #{fixedDate}   </if>
+            <if test="remarks     != null"> , #{remarks}      </if>
+            <if test="isDeleted  != null"> , #{isDeleted}   </if> 
+        )          
+    </insert>	
+	
+    <update id="updateDef" parameterType="com.demo.proworks.defect.vo.DefVo">
+    	<!-- 테스트결함관리를 갱신한다. -->
+    	
+        UPDATE DEFECT    /* QueryID : com.demo.proworks.defect.updateDef */      
+      	  SET  
+                ID           = #{id}                  	                       
+            <if test="testId     != null"> , TEST_ID      = #{testId}      </if>
+            <if test="name        != null"> , NAME         = #{name}         </if>
+            <if test="description != null"> , DESCRIPTION  = #{description}  </if>
+            <if test="priority    != null"> , PRIORITY     = #{priority}     </if>
+            <if test="status      != null"> , STATUS       = #{status}       </if>
+            <if test="createdAt  != null"> , CREATED_AT   = #{createdAt}   </if>
+            <if test="assignee    != null"> , ASSIGNEE     = #{assignee}     </if>
+            <if test="fixDueDate!= null"> , FIX_DUE_DATE = #{fixDueDate} </if>
+            <if test="fixedDate  != null"> , FIXED_DATE   = #{fixedDate}   </if>
+            <if test="remarks     != null"> , REMARKS      = #{remarks}      </if>
+            <if test="isDeleted  != null"> , IS_DELETED   = #{isDeleted}   </if>                 
+        WHERE   
+                ID           = #{id}          
+    </update>
+	
+    <delete id="deleteDef" parameterType="com.demo.proworks.defect.vo.DefVo">
+    	<!-- 테스트결함관리를 삭제한다. -->
+    	
+        DELETE FROM DEFECT   /* QueryID : com.demo.proworks.defect.deleteDef */ 
+        WHERE   
+                ID           = #{id}                  
+    </delete>
+	
+    <select id="selectDef" parameterType="com.demo.proworks.defect.vo.DefVo" resultType="com.demo.proworks.defect.vo.DefVo">
+    	<!-- 테스트결함관리를 상세 조회한다. -->	
+         SELECT     /* QueryID : com.demo.proworks.defect.selectDef */
+        	D.ID as id, 
+	        D.TEST_ID as testId, 
+	        T.NAME as testName,  /* 테스트 이름 추가 */
+	        D.NAME as name, 
+	        D.DESCRIPTION as description, 
+	        D.PRIORITY as priority, 
+	        D.STATUS as status, 
+	        D.CREATED_AT as createdAt, 
+	        D.ASSIGNEE as assignee, 
+	        D.FIX_DUE_DATE as fixDueDate, 
+	        D.FIXED_DATE as fixedDate, 
+	        D.REMARKS as remarks, 
+	        D.IS_DELETED as isDeleted
+	    FROM DEFECT D
+	    LEFT JOIN TEST T ON D.TEST_ID = T.ID  /* 테스트 테이블과 조인 */
+	    WHERE 
+	        D.ID = #{id}   
+    </select>
+	
+    <select id="selectListDef" parameterType="com.demo.proworks.defect.vo.DefVo" resultType="com.demo.proworks.defect.vo.DefVo">
+    	<!-- 테스트결함관리 목록을 조회한다. -->
+           SELECT /* QueryID : com.demo.proworks.test.selectListTest */
+				ID as id,
+				TASK_ID as taskId,
+				TASK_NAME as taskName,
+				NAME as name,
+				CATEGORY as category,
+				SCENARIO as scenario,
+				INPUT_DATA as inputData,
+				EXPECTED_RESULT as expectedResult,
+				ACTUAL_RESULT as actualResult,
+				TEST_RESULT as testResult,
+				ASSIGNEE as assignee,
+				USER_NAME as userName, -- 추가된 부분
+				EXECUTION_DATE as executionDate,
+				DURATION as duration,
+				IS_DELETED as isDeleted,
+				CREATED_AT as createdAt,
+				UPDATED_AT as updatedAt
+				FROM (
+				    SELECT S.*, CEIL( (@ROWNUM:=@ROWNUM+1) / #{pageSize} ) AS PAGE
+				    FROM (
+				        SELECT
+				            test.ID,
+				            test.TASK_ID,
+				            test.NAME,
+				            test.CATEGORY,
+				            test.SCENARIO,
+				            test.INPUT_DATA,
+				            test.EXPECTED_RESULT,
+				            test.ACTUAL_RESULT,
+				            test.TEST_RESULT,
+				            test.ASSIGNEE,
+				            test.EXECUTION_DATE,
+				            test.DURATION,
+				            test.IS_DELETED,
+				            test.CREATED_AT,
+				            test.UPDATED_AT,
+				            task.TASK_NAME as TASK_NAME,
+				            user.NAME as USER_NAME -- 추가된 부분
+				        FROM TEST test
+				        LEFT JOIN TASK task ON test.TASK_ID = task.ID
+				        LEFT JOIN USERS user ON test.ASSIGNEE = user.ID -- 추가된 조인
+				        WHERE 1=1
+				        -- 필요한 조건 추가 (예: AND test.IS_DELETED = 0)
+				    ) S, (SELECT @ROWNUM := 0) TMP
+				) A
+				WHERE PAGE = #{pageIndex}
+    </select>
+	
+    <select id="selectListCountDef" parameterType="com.demo.proworks.defect.vo.DefVo" resultType="long">
+    <!-- 테스트결함관리 목록의 카운트를 조회한다. -->
+    
+         SELECT    /* QueryID : com.demo.proworks.defect.selectListCountDef */
+             COUNT(*) totcnt  		                  
+         FROM DEFECT
+         WHERE  1=1    		
+
+    </select>
+
+</mapper>

--- a/src/main/resources/inswave/sqlmap/com/demo/proworks/iss/issues_risks_SQL_mariadb_MyBatis.xml
+++ b/src/main/resources/inswave/sqlmap/com/demo/proworks/iss/issues_risks_SQL_mariadb_MyBatis.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper      
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"      
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+	@subject     : 이슈리스크관리 관련 처리를 담당하는 Sql Mapper
+	@description : 이슈리스크관리 관련 처리를 담당하는 Sql Mapper
+	@author      : 우민지
+	@since       : 2025/07/07
+	@modification
+	===========================================================
+	DATE              AUTHOR             DESC
+	===========================================================
+	2025/07/07              우민지             최초 생성
+ -->
+<mapper namespace="com.demo.proworks.iss">
+    <insert id="insertIss" parameterType="com.demo.proworks.iss.vo.IssVo">
+    	<!-- 이슈리스크관리를 등록한다. -->	
+    		
+        INSERT INTO ISSUES_RISKS   /* QueryID : com.demo.proworks.iss.insertIss */
+        ( 
+            ID
+            <if test="pjtId       != null"> , PJT_ID        </if>
+            <if test="name         != null"> , NAME          </if>
+            <if test="userId      != null"> , USER_ID       </if>
+            <if test="dueDate     != null"> , DUE_DATE      </if>
+            <if test="status       != null"> , STATUS        </if>
+            <if test="priority     != null"> , PRIORITY      </if>
+            <if test="type         != null"> , TYPE          </if>
+            <if test="description  != null"> , DESCRIPTION   </if>
+            <if test="createdAt   != null"> , CREATED_AT    </if>
+            <if test="updatedAt   != null"> , UPDATED_AT    </if>
+            <if test="resolvedDate!= null"> , RESOLVED_DATE </if>
+            <if test="responsePlan!= null"> , RESPONSE_PLAN </if>
+            <if test="isDeleted   != null"> , IS_DELETED    </if>
+        )
+        VALUES  
+        ( 
+            #{id}
+            <if test="pjtId       != null"> , #{pjtId}        </if>
+            <if test="name         != null"> , #{name}          </if>
+            <if test="userId      != null"> , #{userId}       </if>
+            <if test="dueDate     != null"> , #{dueDate}      </if>
+            <if test="status       != null"> , #{status}        </if>
+            <if test="priority     != null"> , #{priority}      </if>
+            <if test="type         != null"> , #{type}          </if>
+            <if test="description  != null"> , #{description}   </if>
+            <if test="createdAt   != null"> , #{createdAt}    </if>
+            <if test="updatedAt   != null"> , #{updatedAt}    </if>
+            <if test="resolvedDate!= null"> , #{resolvedDate} </if>
+            <if test="responsePlan!= null"> , #{responsePlan} </if>
+            <if test="isDeleted   != null"> , #{isDeleted}    </if> 
+        )          
+    </insert>	
+	
+    <update id="updateIss" parameterType="com.demo.proworks.iss.vo.IssVo">
+    	<!-- 이슈리스크관리를 갱신한다. -->
+    	
+        UPDATE ISSUES_RISKS    /* QueryID : com.demo.proworks.iss.updateIss */      
+      	  SET  
+                ID            = #{id}                   	                       
+            <if test="pjtId       != null"> , PJT_ID        = #{pjtId}        </if>
+            <if test="name         != null"> , NAME          = #{name}          </if>
+            <if test="userId      != null"> , USER_ID       = #{userId}       </if>
+            <if test="dueDate     != null"> , DUE_DATE      = #{dueDate}      </if>
+            <if test="status       != null"> , STATUS        = #{status}        </if>
+            <if test="priority     != null"> , PRIORITY      = #{priority}      </if>
+            <if test="type         != null"> , TYPE          = #{type}          </if>
+            <if test="description  != null"> , DESCRIPTION   = #{description}   </if>
+            <if test="createdAt   != null"> , CREATED_AT    = #{createdAt}    </if>
+            <if test="updatedAt   != null"> , UPDATED_AT    = #{updatedAt}    </if>
+            <if test="resolvedDate!= null"> , RESOLVED_DATE = #{resolvedDate} </if>
+            <if test="responsePlan!= null"> , RESPONSE_PLAN = #{responsePlan} </if>
+            <if test="isDeleted   != null"> , IS_DELETED    = #{isDeleted}    </if>                 
+        WHERE   
+                ID            = #{id}           
+    </update>
+	
+    <delete id="deleteIss" parameterType="com.demo.proworks.iss.vo.IssVo">
+    	<!-- 이슈리스크관리를 삭제한다. -->
+    	
+        DELETE FROM ISSUES_RISKS   /* QueryID : com.demo.proworks.iss.deleteIss */ 
+        WHERE   
+                ID            = #{id}                   
+    </delete>
+	
+    <select id="selectIss" parameterType="com.demo.proworks.iss.vo.IssVo" resultType="com.demo.proworks.iss.vo.IssVo">
+    	<!-- 이슈리스크관리를 상세 조회한다. -->	
+        SELECT     /* QueryID : com.demo.proworks.iss.selectIss */
+            PJT_ID as pjtId, ID as id, NAME as name, USER_ID as userId, DUE_DATE as dueDate, STATUS as status, PRIORITY as priority, TYPE as type, DESCRIPTION as description, CREATED_AT as createdAt, UPDATED_AT as updatedAt, RESOLVED_DATE as resolvedDate, RESPONSE_PLAN as responsePlan, IS_DELETED as isDeleted
+        FROM ISSUES_RISKS 
+        WHERE 
+                ID            = #{id}           			
+    </select>
+	
+    <select id="selectListIss" parameterType="com.demo.proworks.iss.vo.IssVo" resultType="com.demo.proworks.iss.vo.IssVo">
+    	<!-- 이슈리스크관리 목록을 조회한다. -->
+           SELECT    /* QueryID : com.demo.proworks.iss.selectListIss */
+               PJT_ID as pjtId, ID as id, NAME as name, USER_ID as userId, DUE_DATE as dueDate, STATUS as status, PRIORITY as priority, TYPE as type, DESCRIPTION as description, CREATED_AT as createdAt, UPDATED_AT as updatedAt, RESOLVED_DATE as resolvedDate, RESPONSE_PLAN as responsePlan, IS_DELETED as isDeleted		       
+           FROM (
+               SELECT  S.*, CEIL( (@ROWNUM:=@ROWNUM+1) / #{pageSize} ) AS PAGE
+               FROM (				
+                   SELECT 
+                       *  		                  
+                   FROM ISSUES_RISKS
+                   WHERE  1=1    		
+	     																														
+               ) S, (SELECT @ROWNUM := 0) TMP
+           ) A
+            WHERE PAGE = #{pageIndex}
+    </select>
+	
+    <select id="selectListCountIss" parameterType="com.demo.proworks.iss.vo.IssVo" resultType="long">
+    <!-- 이슈리스크관리 목록의 카운트를 조회한다. -->
+    
+         SELECT    /* QueryID : com.demo.proworks.iss.selectListCountIss */
+             COUNT(*) totcnt  		                  
+         FROM ISSUES_RISKS
+         WHERE  1=1    		
+
+    </select>
+
+</mapper>

--- a/src/main/resources/inswave/sqlmap/com/demo/proworks/out/output_SQL_mariadb_MyBatis.xml
+++ b/src/main/resources/inswave/sqlmap/com/demo/proworks/out/output_SQL_mariadb_MyBatis.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper      
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"      
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+	@subject     : 산출물관리 관련 처리를 담당하는 Sql Mapper
+	@description : 산출물관리 관련 처리를 담당하는 Sql Mapper
+	@author      : 우민지
+	@since       : 2025/07/07
+	@modification
+	===========================================================
+	DATE              AUTHOR             DESC
+	===========================================================
+	2025/07/07              우민지             최초 생성
+ -->
+<mapper namespace="com.demo.proworks.out">
+    <insert id="insertOut" parameterType="com.demo.proworks.out.vo.OutVo">
+    	<!-- 산출물관리를 등록한다. -->	
+    		
+        INSERT INTO OUTPUT   /* QueryID : com.demo.proworks.out.insertOut */
+        ( 
+            ID
+            <if test="pjtId          != null"> , PJT_ID           </if>
+            <if test="name            != null"> , NAME             </if>
+            <if test="createdAt      != null"> , CREATED_AT       </if>
+            <if test="updatedAt      != null"> , UPDATED_AT       </if>
+            <if test="approvalStatus != null"> , APPROVAL_STATUS  </if>
+            <if test="approvalDate   != null"> , APPROVAL_DATE    </if>
+            <if test="approvalComment!= null"> , APPROVAL_COMMENT </if>
+            <if test="outputType     != null"> , OUTPUT_TYPE      </if>
+            <if test="isDeleted      != null"> , IS_DELETED       </if>
+        )
+        VALUES  
+        ( 
+            #{id}
+            <if test="pjtId          != null"> , #{pjtId}           </if>
+            <if test="name            != null"> , #{name}             </if>
+            <if test="createdAt      != null"> , #{createdAt}       </if>
+            <if test="updatedAt      != null"> , #{updatedAt}       </if>
+            <if test="approvalStatus != null"> , #{approvalStatus}  </if>
+            <if test="approvalDate   != null"> , #{approvalDate}    </if>
+            <if test="approvalComment!= null"> , #{approvalComment} </if>
+            <if test="outputType     != null"> , #{outputType}      </if>
+            <if test="isDeleted      != null"> , #{isDeleted}       </if> 
+        )          
+    </insert>	
+	
+    <update id="updateOut" parameterType="com.demo.proworks.out.vo.OutVo">
+    	<!-- 산출물관리를 갱신한다. -->
+    	
+        UPDATE OUTPUT    /* QueryID : com.demo.proworks.out.updateOut */      
+      	  SET  
+                ID               = #{id}                      	                       
+            <if test="pjtId          != null"> , PJT_ID           = #{pjtId}           </if>
+            <if test="name            != null"> , NAME             = #{name}             </if>
+            <if test="createdAt      != null"> , CREATED_AT       = #{createdAt}       </if>
+            <if test="updatedAt      != null"> , UPDATED_AT       = #{updatedAt}       </if>
+            <if test="approvalStatus != null"> , APPROVAL_STATUS  = #{approvalStatus}  </if>
+            <if test="approvalDate   != null"> , APPROVAL_DATE    = #{approvalDate}    </if>
+            <if test="approvalComment!= null"> , APPROVAL_COMMENT = #{approvalComment} </if>
+            <if test="outputType     != null"> , OUTPUT_TYPE      = #{outputType}      </if>
+            <if test="isDeleted      != null"> , IS_DELETED       = #{isDeleted}       </if>                 
+        WHERE   
+                ID               = #{id}              
+    </update>
+	
+    <delete id="deleteOut" parameterType="com.demo.proworks.out.vo.OutVo">
+    	<!-- 산출물관리를 삭제한다. -->
+    	
+        DELETE FROM OUTPUT   /* QueryID : com.demo.proworks.out.deleteOut */ 
+        WHERE   
+                ID               = #{id}                      
+    </delete>
+	
+    <select id="selectOut" parameterType="com.demo.proworks.out.vo.OutVo" resultType="com.demo.proworks.out.vo.OutVo">
+    	<!-- 산출물관리를 상세 조회한다. -->	
+        SELECT     /* QueryID : com.demo.proworks.out.selectOut */
+            ID as id, PJT_ID as pjtId, NAME as name, CREATED_AT as createdAt, UPDATED_AT as updatedAt, APPROVAL_STATUS as approvalStatus, APPROVAL_DATE as approvalDate, APPROVAL_COMMENT as approvalComment, OUTPUT_TYPE as outputType, IS_DELETED as isDeleted
+        FROM OUTPUT 
+        WHERE 
+                ID               = #{id}              			
+    </select>
+	
+    <select id="selectListOut" parameterType="com.demo.proworks.out.vo.OutVo" resultType="com.demo.proworks.out.vo.OutVo">
+    	<!-- 산출물관리 목록을 조회한다. -->
+           SELECT    /* QueryID : com.demo.proworks.out.selectListOut */
+               ID as id, PJT_ID as pjtId, NAME as name, CREATED_AT as createdAt, UPDATED_AT as updatedAt, APPROVAL_STATUS as approvalStatus, APPROVAL_DATE as approvalDate, APPROVAL_COMMENT as approvalComment, OUTPUT_TYPE as outputType, IS_DELETED as isDeleted		       
+           FROM (
+               SELECT  S.*, CEIL( (@ROWNUM:=@ROWNUM+1) / #{pageSize} ) AS PAGE
+               FROM (				
+                   SELECT 
+                       *  		                  
+                   FROM OUTPUT
+                   WHERE  1=1    		
+	     																														
+               ) S, (SELECT @ROWNUM := 0) TMP
+           ) A
+            WHERE PAGE = #{pageIndex}
+    </select>
+	
+    <select id="selectListCountOut" parameterType="com.demo.proworks.out.vo.OutVo" resultType="long">
+    <!-- 산출물관리 목록의 카운트를 조회한다. -->
+    
+         SELECT    /* QueryID : com.demo.proworks.out.selectListCountOut */
+             COUNT(*) totcnt  		                  
+         FROM OUTPUT
+         WHERE  1=1    		
+
+    </select>
+
+</mapper>

--- a/src/main/resources/inswave/sqlmap/com/demo/proworks/test/test_SQL_mariadb_MyBatis.xml
+++ b/src/main/resources/inswave/sqlmap/com/demo/proworks/test/test_SQL_mariadb_MyBatis.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper      
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"      
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+	@subject     : 테스트관리 관련 처리를 담당하는 Sql Mapper
+	@description : 테스트관리 관련 처리를 담당하는 Sql Mapper
+	@author      : 우민지
+	@since       : 2025/07/07
+	@modification
+	===========================================================
+	DATE              AUTHOR             DESC
+	===========================================================
+	2025/07/07              우민지             최초 생성
+ -->
+<mapper namespace="com.demo.proworks.test">
+    <insert id="insertTest" parameterType="com.demo.proworks.test.vo.TestVo">
+    	<!-- 테스트관리를 등록한다. -->	
+    		
+        INSERT INTO TEST   /* QueryID : com.demo.proworks.test.insertTest */
+        ( 
+            ID
+            <if test="taskId        != null"> , TASK_ID         </if>
+            <if test="name           != null"> , NAME            </if>
+            <if test="category       != null"> , CATEGORY        </if>
+            <if test="scenario       != null"> , SCENARIO        </if>
+            <if test="inputData     != null"> , INPUT_DATA      </if>
+            <if test="expectedResult!= null"> , EXPECTED_RESULT </if>
+            <if test="actualResult  != null"> , ACTUAL_RESULT   </if>
+            <if test="testResult    != null"> , TEST_RESULT     </if>
+            <if test="assignee       != null"> , ASSIGNEE        </if>
+            <if test="executionDate != null"> , EXECUTION_DATE  </if>
+            <if test="duration       != null"> , DURATION        </if>
+            <if test="isDeleted     != null"> , IS_DELETED      </if>
+            <if test="createdAt     != null"> , CREATED_AT      </if>
+            <if test="updatedAt     != null"> , UPDATED_AT      </if>
+        )
+        VALUES  
+        ( 
+            #{id}
+            <if test="taskId        != null"> , #{taskId}         </if>
+            <if test="name           != null"> , #{name}            </if>
+            <if test="category       != null"> , #{category}        </if>
+            <if test="scenario       != null"> , #{scenario}        </if>
+            <if test="inputData     != null"> , #{inputData}      </if>
+            <if test="expectedResult!= null"> , #{expectedResult} </if>
+            <if test="actualResult  != null"> , #{actualResult}   </if>
+            <if test="testResult    != null"> , #{testResult}     </if>
+            <if test="assignee       != null"> , #{assignee}        </if>
+            <if test="executionDate != null"> , #{executionDate}  </if>
+            <if test="duration       != null"> , #{duration}        </if>
+            <if test="isDeleted     != null"> , #{isDeleted}      </if>
+            <if test="createdAt     != null"> , #{createdAt}      </if>
+            <if test="updatedAt     != null"> , #{updatedAt}      </if> 
+        )          
+    </insert>	
+	
+    <update id="updateTest" parameterType="com.demo.proworks.test.vo.TestVo">
+    	<!-- 테스트관리를 갱신한다. -->
+    	
+        UPDATE TEST    /* QueryID : com.demo.proworks.test.updateTest */      
+      	  SET  
+                ID              = #{id}                     	                       
+            <if test="taskId        != null"> , TASK_ID         = #{taskId}         </if>
+            <if test="name           != null"> , NAME            = #{name}            </if>
+            <if test="category       != null"> , CATEGORY        = #{category}        </if>
+            <if test="scenario       != null"> , SCENARIO        = #{scenario}        </if>
+            <if test="inputData     != null"> , INPUT_DATA      = #{inputData}      </if>
+            <if test="expectedResult!= null"> , EXPECTED_RESULT = #{expectedResult} </if>
+            <if test="actualResult  != null"> , ACTUAL_RESULT   = #{actualResult}   </if>
+            <if test="testResult    != null"> , TEST_RESULT     = #{testResult}     </if>
+            <if test="assignee       != null"> , ASSIGNEE        = #{assignee}        </if>
+            <if test="executionDate != null"> , EXECUTION_DATE  = #{executionDate}  </if>
+            <if test="duration       != null"> , DURATION        = #{duration}        </if>
+            <if test="isDeleted     != null"> , IS_DELETED      = #{isDeleted}      </if>
+            <if test="createdAt     != null"> , CREATED_AT      = #{createdAt}      </if>
+            <if test="updatedAt     != null"> , UPDATED_AT      = #{updatedAt}      </if>                 
+        WHERE   
+                ID              = #{id}             
+    </update>
+	
+    <delete id="deleteTest" parameterType="com.demo.proworks.test.vo.TestVo">
+    	<!-- 테스트관리를 삭제한다. -->
+    	
+        DELETE FROM TEST   /* QueryID : com.demo.proworks.test.deleteTest */ 
+        WHERE   
+                ID              = #{id}                     
+    </delete>
+	
+    <select id="selectTest" parameterType="com.demo.proworks.test.vo.TestVo" resultType="com.demo.proworks.test.vo.TestVo">
+    	<!-- 테스트관리를 상세 조회한다. -->	
+        SELECT     /* QueryID : com.demo.proworks.test.selectTest */
+            ID as id, TASK_ID as taskId, NAME as name, CATEGORY as category, SCENARIO as scenario, INPUT_DATA as inputData, EXPECTED_RESULT as expectedResult, ACTUAL_RESULT as actualResult, TEST_RESULT as testResult, ASSIGNEE as assignee, EXECUTION_DATE as executionDate, DURATION as duration, IS_DELETED as isDeleted, CREATED_AT as createdAt, UPDATED_AT as updatedAt
+        FROM TEST 
+        WHERE 
+                ID              = #{id}             			
+    </select>
+	
+    <select id="selectListTest" parameterType="com.demo.proworks.test.vo.TestVo" resultType="com.demo.proworks.test.vo.TestVo">
+    	<!-- 테스트관리 목록을 조회한다. -->
+          SELECT /* QueryID : com.demo.proworks.test.selectListTest */
+			ID as id,
+			TASK_ID as taskId,
+			TASK_NAME as taskName,
+			NAME as name,
+			CATEGORY as category,
+			SCENARIO as scenario,
+			INPUT_DATA as inputData,
+			EXPECTED_RESULT as expectedResult,
+			ACTUAL_RESULT as actualResult,
+			TEST_RESULT as testResult,
+			ASSIGNEE as assignee,
+			USER_NAME as userName, -- 추가된 부분
+			EXECUTION_DATE as executionDate,
+			DURATION as duration,
+			IS_DELETED as isDeleted,
+			CREATED_AT as createdAt,
+			UPDATED_AT as updatedAt
+			FROM (
+			    SELECT S.*, CEIL( (@ROWNUM:=@ROWNUM+1) / #{pageSize} ) AS PAGE
+			    FROM (
+			        SELECT
+			            test.ID,
+			            test.TASK_ID,
+			            test.NAME,
+			            test.CATEGORY,
+			            test.SCENARIO,
+			            test.INPUT_DATA,
+			            test.EXPECTED_RESULT,
+			            test.ACTUAL_RESULT,
+			            test.TEST_RESULT,
+			            test.ASSIGNEE,
+			            test.EXECUTION_DATE,
+			            test.DURATION,
+			            test.IS_DELETED,
+			            test.CREATED_AT,
+			            test.UPDATED_AT,
+			            task.TASK_NAME as TASK_NAME,
+			            user.NAME as USER_NAME -- 추가된 부분
+			        FROM TEST test
+			        LEFT JOIN TASK task ON test.TASK_ID = task.TASK_ID
+			        LEFT JOIN USERS user ON test.ASSIGNEE = user.USER_ID -- 추가된 조인
+			        WHERE 1=1
+			        -- 필요한 조건 추가 (예: AND test.IS_DELETED = 0)
+			    ) S, (SELECT @ROWNUM := 0) TMP
+			) A
+			WHERE PAGE = #{pageIndex}
+    </select>
+	
+    <select id="selectListCountTest" parameterType="com.demo.proworks.test.vo.TestVo" resultType="long">
+    <!-- 테스트관리 목록의 카운트를 조회한다. -->
+    
+         SELECT    /* QueryID : com.demo.proworks.test.selectListCountTest */
+             COUNT(*) totcnt  		                  
+         FROM TEST
+         WHERE  1=1    		
+
+    </select>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/faces-config.xml
+++ b/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd"
+    version="2.2">
+
+</faces-config>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,163 +1,140 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app id="WebApp_ID" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
-	
-	<display-name>GInsWebApp.InsWebApp</display-name>
-	<filter>
-		<filter-name>encodingFilter</filter-name>
-		<filter-class>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" id="WebApp_ID" version="3.1">
+  <display-name>GInsWebApp.InsWebApp</display-name>
+  <filter>
+    <filter-name>encodingFilter</filter-name>
+    <filter-class>
 			org.springframework.web.filter.CharacterEncodingFilter
 		</filter-class>
-		<init-param>
-			<param-name>encoding</param-name>
-			<param-value>utf-8</param-value>
-		</init-param>
-	</filter>    
-	<filter>
-        <filter-name>HTMLTagFilter</filter-name>
-        <filter-class>
+    <init-param>
+      <param-name>encoding</param-name>
+      <param-value>utf-8</param-value>
+    </init-param>
+  </filter>
+  <filter>
+    <filter-name>HTMLTagFilter</filter-name>
+    <filter-class>
             com.inswave.elfw.mvc.filter.HTMLTagFilter
         </filter-class>
-    </filter>
-	<filter-mapping>
-		<filter-name>encodingFilter</filter-name>
-		<url-pattern>/*</url-pattern>
-	</filter-mapping>
-	<filter-mapping>
-        <filter-name>HTMLTagFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>	
-    
-  	<filter>
-        <filter-name>elFilter</filter-name>
-        <filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>encodingFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>HTMLTagFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  <filter>
+    <filter-name>elFilter</filter-name>
+    <filter-class>
             com.inswave.elfw.intercept.ElServletFilter
         </filter-class>
-    </filter>   
-	<filter-mapping>
-        <filter-name>elFilter</filter-name>
-        <url-pattern>*.fld</url-pattern>
-    </filter-mapping>  
-	<filter-mapping>
-        <filter-name>elFilter</filter-name>
-        <url-pattern>*.pwkjson</url-pattern>
-    </filter-mapping>    
-
-	<filter-mapping>
-        <filter-name>elFilter</filter-name>
-        <url-pattern>*.pwkxml</url-pattern>
-    </filter-mapping>  
-    
-    <!-- JSPC servlet mappings start -->	
-	<servlet>
-         <servlet-name>websquareDispatcher</servlet-name>
-         <servlet-class>websquare.http.DefaultRequestDispatcher</servlet-class>
-   </servlet>
-   <servlet-mapping>
-         <servlet-name>websquareDispatcher</servlet-name>
-         <url-pattern>*.wq</url-pattern>
-   </servlet-mapping>
-   <servlet>
-		<servlet-name>matrix-mobile</servlet-name>
-        <servlet-class>inswave.matrix.mobile.servlet.MatrixMobileServlet</servlet-class>
-		<init-param>
-			<param-name>MATRIX_MOBILE_HOME</param-name>
-			<param-value>C:\InswaveToolSP1\workspace\InsWebApp\matrix_mobile_home</param-value>
-		</init-param>
-	</servlet>
-	<servlet-mapping>
-        <servlet-name>matrix-mobile</servlet-name>
-        <url-pattern>/matrix-mobile</url-pattern>
-    </servlet-mapping>
-	<!-- JSPC servlet mappings end -->
-        
-	<context-param>
-		<param-name>contextConfigLocation</param-name>
-		<param-value>
+  </filter>
+  <filter-mapping>
+    <filter-name>elFilter</filter-name>
+    <url-pattern>*.fld</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>elFilter</filter-name>
+    <url-pattern>*.pwkjson</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>elFilter</filter-name>
+    <url-pattern>*.pwkxml</url-pattern>
+  </filter-mapping>
+  <servlet>
+    <servlet-name>websquareDispatcher</servlet-name>
+    <servlet-class>websquare.http.DefaultRequestDispatcher</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>websquareDispatcher</servlet-name>
+    <url-pattern>*.wq</url-pattern>
+  </servlet-mapping>
+  <servlet>
+    <servlet-name>matrix-mobile</servlet-name>
+    <servlet-class>inswave.matrix.mobile.servlet.MatrixMobileServlet</servlet-class>
+    <init-param>
+      <param-name>MATRIX_MOBILE_HOME</param-name>
+      <param-value>C:\InswaveToolSP1\workspace\InsWebApp\matrix_mobile_home</param-value>
+    </init-param>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>matrix-mobile</servlet-name>
+    <url-pattern>/matrix-mobile</url-pattern>
+  </servlet-mapping>
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>
 				classpath*:inswave/spring/context-*.xml
 		</param-value>
-	</context-param>
-	
-	<listener>
-		<listener-class>com.demo.proworks.cmmn.ProworksContextLoaderListener</listener-class>
-	</listener>	
-	
-	<servlet>
-		<servlet-name>action</servlet-name>
-		<servlet-class>
+  </context-param>
+  <listener>
+    <listener-class>com.demo.proworks.cmmn.ProworksContextLoaderListener</listener-class>
+  </listener>
+  <servlet>
+    <servlet-name>action</servlet-name>
+    <servlet-class>
 			org.springframework.web.servlet.DispatcherServlet
 		</servlet-class>
-		<init-param>
-			<param-name>contextConfigLocation</param-name>
-			<param-value>
+    <init-param>
+      <param-name>contextConfigLocation</param-name>
+      <param-value>
 				/WEB-INF/config/inswave/springmvc/dispatcher-servlet.xml,
 				/WEB-INF/config/inswave/springmvc/urlfilename-servlet.xml
 			</param-value>
-		</init-param>
-		<load-on-startup>1</load-on-startup>
-	</servlet>
-	<servlet-mapping>
-		<servlet-name>action</servlet-name>
-		<url-pattern>*.do</url-pattern>
-	</servlet-mapping>
-		
-	<servlet-mapping>
-		<servlet-name>action</servlet-name>
-		<url-pattern>*.pwkjson</url-pattern>
-	</servlet-mapping>	
-	
-	<servlet-mapping>
-		<servlet-name>action</servlet-name>
-		<url-pattern>*.pwkxml</url-pattern>
-	</servlet-mapping>	
-	
-	<servlet-mapping>
-		<servlet-name>action</servlet-name>
-		<url-pattern>*.test</url-pattern>
-	</servlet-mapping>		
-	
-	<servlet-mapping>
-		<servlet-name>action</servlet-name>
-		<url-pattern>*.xform</url-pattern>
-	</servlet-mapping>		
-		
-	
-	<servlet-mapping>
-		<servlet-name>action</servlet-name>
-		<url-pattern>*.fld</url-pattern>
-	</servlet-mapping>			
-			
-	<!-- servlet>
-		<servlet-name>CXFServlet</servlet-name>		
-		<servlet-class>
-		org.apache.cxf.transport.servlet.CXFServlet
-		</servlet-class>
-		<load-on-startup>1</load-on-startup>
-	</servlet>
-	<servlet-mapping>
-		<servlet-name>CXFServlet</servlet-name>
-		<url-pattern>/webservice/*</url-pattern>
-	</servlet-mapping -->	
-
-	
-	<welcome-file-list>
-		<welcome-file>index.jsp</welcome-file>
-	</welcome-file-list>
-	<login-config>
-		<auth-method>BASIC</auth-method>
-	</login-config>
-	
-	<error-page>
-        <exception-type>java.lang.Throwable</exception-type>
-        <location>/InsWebApp/common/error.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>404</error-code>
-        <location>/InsWebApp/common/error.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>500</error-code>
-        <location>/InsWebApp/common/error.jsp</location>
-    </error-page>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>action</servlet-name>
+    <url-pattern>*.do</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>action</servlet-name>
+    <url-pattern>*.pwkjson</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>action</servlet-name>
+    <url-pattern>*.pwkxml</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>action</servlet-name>
+    <url-pattern>*.test</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>action</servlet-name>
+    <url-pattern>*.xform</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>action</servlet-name>
+    <url-pattern>*.fld</url-pattern>
+  </servlet-mapping>
+  <welcome-file-list>
+    <welcome-file>index.jsp</welcome-file>
+  </welcome-file-list>
+  <login-config>
+    <auth-method>BASIC</auth-method>
+  </login-config>
+  <error-page>
+    <exception-type>java.lang.Throwable</exception-type>
+    <location>/InsWebApp/common/error.jsp</location>
+  </error-page>
+  <error-page>
+    <error-code>404</error-code>
+    <location>/InsWebApp/common/error.jsp</location>
+  </error-page>
+  <error-page>
+    <error-code>500</error-code>
+    <location>/InsWebApp/common/error.jsp</location>
+  </error-page>
+  <servlet>
+    <servlet-name>Faces Servlet</servlet-name>
+    <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>/faces/*</url-pattern>
+  </servlet-mapping>
 </web-app>

--- a/src/main/webapp/ui/def/Def.xml
+++ b/src/main/webapp/ui/def/Def.xml
@@ -1,0 +1,1301 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_defVo" style="">
+					<w2:keyInfo>
+
+						<w2:key dataType="text" id="pageIndex" name="페이지번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지사이즈" defaultValue="10"></w2:key>
+						<w2:key dataType="text" id="totalPageCount" name="페이지건수"></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_defVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="결함 고유 ID"></w2:column>
+						<w2:column dataType="text" id="testId" name="연결된 테스트 ID"></w2:column>
+                        <w2:column dataType="text" id="testName" name="테스트 케이스명"></w2:column>  <!-- 추가 -->
+						<w2:column dataType="text" id="name" name="결함명"></w2:column>
+						<w2:column dataType="text" id="description" name="결함 상세 설명"></w2:column>
+						<w2:column dataType="text" id="priority" name="우선순위 (Critical/High/Medium/Low)"></w2:column>
+						<w2:column dataType="text" id="status" name="상태 (신규/진행중/수정완료/재오픈/종료)"></w2:column>
+						<w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+						<w2:column dataType="text" id="assignee" name="수정 담당자"></w2:column>
+                        <w2:column dataType="text" id="userName" name="수정 담당자"></w2:column>
+						<w2:column dataType="text" id="fixDueDate" name="수정 기한"></w2:column>
+						<w2:column dataType="text" id="fixedDate" name="수정 완료일"></w2:column>
+						<w2:column dataType="text" id="remarks" name="비고사항"></w2:column>
+						<w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+
+					</w2:columnInfo>
+				</w2:dataList>
+                <w2:dataList baseNode="list" id="dlt_waitingList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="결함 고유 ID"></w2:column>
+						<w2:column dataType="text" id="testId" name="연결된 테스트 ID"></w2:column>
+                        <w2:column dataType="text" id="testName" name="테스트 케이스명"></w2:column>  <!-- 추가 --> 
+						<w2:column dataType="text" id="name" name="결함명"></w2:column>
+						<w2:column dataType="text" id="description" name="결함 상세 설명"></w2:column>
+						<w2:column dataType="text" id="priority" name="우선순위 (Critical/High/Medium/Low)"></w2:column>
+						<w2:column dataType="text" id="status" name="상태 (신규/진행중/수정완료/재오픈/종료)"></w2:column>
+						<w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+						<w2:column dataType="text" id="assignee" name="수정 담당자"></w2:column>
+                        <w2:column dataType="text" id="userName" name="수정 담당자"></w2:column>
+						<w2:column dataType="text" id="fixDueDate" name="수정 기한"></w2:column>
+						<w2:column dataType="text" id="fixedDate" name="수정 완료일"></w2:column>
+						<w2:column dataType="text" id="remarks" name="비고사항"></w2:column>
+						<w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+					</w2:columnInfo>
+				</w2:dataList>
+                <w2:dataList baseNode="list" id="dlt_processingList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="결함 고유 ID"></w2:column>
+						<w2:column dataType="text" id="testId" name="연결된 테스트 ID"></w2:column>
+                        <w2:column dataType="text" id="testName" name="테스트 케이스명"></w2:column>  <!-- 추가 -->
+						<w2:column dataType="text" id="name" name="결함명"></w2:column>
+						<w2:column dataType="text" id="description" name="결함 상세 설명"></w2:column>
+						<w2:column dataType="text" id="priority" name="우선순위 (Critical/High/Medium/Low)"></w2:column>
+						<w2:column dataType="text" id="status" name="상태 (신규/진행중/수정완료/재오픈/종료)"></w2:column>
+						<w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+						<w2:column dataType="text" id="assignee" name="수정 담당자"></w2:column>
+                        <w2:column dataType="text" id="userName" name="수정 담당자"></w2:column>
+						<w2:column dataType="text" id="fixDueDate" name="수정 기한"></w2:column>
+						<w2:column dataType="text" id="fixedDate" name="수정 완료일"></w2:column>
+						<w2:column dataType="text" id="remarks" name="비고사항"></w2:column>
+						<w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+					</w2:columnInfo>
+				</w2:dataList>
+                <w2:dataList baseNode="list" id="dlt_completedList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="결함 고유 ID"></w2:column>
+						<w2:column dataType="text" id="testId" name="연결된 테스트 ID"></w2:column>
+                        <w2:column dataType="text" id="testName" name="테스트 케이스명"></w2:column>  <!-- 추가 -->
+						<w2:column dataType="text" id="name" name="결함명"></w2:column>
+						<w2:column dataType="text" id="description" name="결함 상세 설명"></w2:column>
+						<w2:column dataType="text" id="priority" name="우선순위 (Critical/High/Medium/Low)"></w2:column>
+						<w2:column dataType="text" id="status" name="상태 (신규/진행중/수정완료/재오픈/종료)"></w2:column>
+						<w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+						<w2:column dataType="text" id="assignee" name="수정 담당자"></w2:column>
+                        <w2:column dataType="text" id="userName" name="수정 담당자"></w2:column>
+						<w2:column dataType="text" id="fixDueDate" name="수정 기한"></w2:column>
+						<w2:column dataType="text" id="fixedDate" name="수정 완료일"></w2:column>
+						<w2:column dataType="text" id="remarks" name="비고사항"></w2:column>
+						<w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_defVoDetail" style="">
+					<w2:keyInfo>
+						<w2:key dataType="text" id="id" name="결함 고유 ID"></w2:key>
+						<w2:key dataType="text" id="testId" name="연결된 테스트 ID"></w2:key>
+                        <w2:column dataType="text" id="testName" name="테스트 케이스명"></w2:column>  <!-- 추가 -->
+						<w2:key dataType="text" id="name" name="결함명"></w2:key>
+						<w2:key dataType="text" id="description" name="결함 상세 설명"></w2:key>
+						<w2:key dataType="text" id="priority" name="우선순위 (Critical/High/Medium/Low)"></w2:key>
+						<w2:key dataType="text" id="status" name="상태 (신규/진행중/수정완료/재오픈/종료)"></w2:key>
+						<w2:key dataType="text" id="createdAt" name="등록일시"></w2:key>
+						<w2:key dataType="text" id="assignee" name="수정 담당자"></w2:key>
+                        <w2:column dataType="text" id="userName" name="수정 담당자"></w2:column>
+						<w2:key dataType="text" id="fixDueDate" name="수정 기한"></w2:key>
+						<w2:key dataType="text" id="fixedDate" name="수정 완료일"></w2:key>
+						<w2:key dataType="text" id="remarks" name="비고사항"></w2:key>
+						<w2:key dataType="text" id="isDeleted" name="삭제 여부"></w2:key>
+
+					</w2:keyInfo>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" repeatNode="map" id="dlt_status" saveRemovedData="true">
+					<w2:columnInfo>
+						<w2:column dataType="text" name="코드" id="code"></w2:column>
+						<w2:column dataType="text" name="상태" id="status"></w2:column>
+					</w2:columnInfo>
+					<w2:data use="true">
+						<w2:row>
+							<code><![CDATA[NEW]]></code>
+							<status><![CDATA[신규]]></status>
+						</w2:row>
+						<w2:row>
+							<code><![CDATA[IPR]]></code>
+							<status><![CDATA[진행중]]></status>
+						</w2:row>
+						<w2:row>
+							<code><![CDATA[COM]]></code>
+							<status><![CDATA[완료]]></status>
+						</w2:row>
+					</w2:data>
+				</w2:dataList>
+				<w2:dataList baseNode="list" repeatNode="map" id="dlt_priority" saveRemovedData="true">
+					<w2:columnInfo>
+						<w2:column dataType="text" name="코드" id="code"></w2:column>
+						<w2:column dataType="text" name="우선순위" id="priority"></w2:column>
+					</w2:columnInfo>
+					<w2:data use="true">
+						<w2:row>
+							<code><![CDATA[CR]]></code>
+							<priority><![CDATA[긴급]]></priority>
+						</w2:row>
+						<w2:row>
+							<code><![CDATA[HI]]></code>
+							<priority><![CDATA[높음]]></priority>
+						</w2:row>
+						<w2:row>
+							<code><![CDATA[MD]]></code>
+							<priority><![CDATA[보통]]></priority>
+						</w2:row>
+						<w2:row>
+							<code><![CDATA[LO]]></code>
+							<priority><![CDATA[낮음]]></priority>
+						</w2:row>
+					</w2:data>
+				</w2:dataList>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectDefVoList" ref='data:json,{"id":"dmp_defVo","key":"defVo"}'
+				target='data:json,{"id":"dlt_defVoList","key":"elData.defVoList"}' action="/InsWebApp/DEF001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="테스트결함관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_defList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_deleteDefVo" ref='data:json,{"id":"dmp_defVoDetail","key":"defVo"}' target="" action="/InsWebApp/DEF001Del.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_deleteDefVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_updateDefVo" ref='data:json,["dmp_defVoDetail",{"id":"dmp_defVoDetail","key":"defVo"}]' target="" action="/InsWebApp/DEF001Upd.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_updateDefVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_insertDefVo" ref='data:json,["dmp_defVoDetail",{"id":"dmp_defVoDetail","key":"defVo"}]' target="" action="/InsWebApp/DEF001Ins.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_insertDefVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_selectDefVo" ref="" target="" action="/InsWebApp/DEF001UpdView.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="테스트결함관리를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_selectDefVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {
+		// 테스트결함관리 readOnly false
+		
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼 
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//sel_pageSize.setValue("10");
+		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 테스트결함관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_defVo.set("pageIndex","1");
+		pgl_defList.setSelectedIndex(1);
+
+		// 서버통신 - 테스트결함관리 조회
+		$c.sbm.execute($p, sbm_selectDefVoList);
+	};
+	
+	scwin.sbm_defList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+        var allData = elData.defVoList || [];
+        var waitingData = [];    // PEN - 대기
+        var processingData = []; // IPR - 진행중
+        var completedData = [];  // COM - 완료
+
+        // 데이터 분류
+        for(var i = 0; i < allData.length; i++) {
+            var item = allData[i];
+            if(item.status === "NEW") {
+                waitingData.push(item);
+            } else if(item.status === "IPR") {
+                processingData.push(item);
+            } else if(item.status === "COM") {
+                completedData.push(item);
+            }
+        }
+        console.log("allData",allData)
+
+
+        //신규 그리드 업데이트
+        console.log("waitingData",waitingData)
+        dlt_waitingList.setJSON(waitingData);
+        spn_waitListCnt.setLabel(waitingData.length)
+
+        // 신규 그리드 네비게이터 업데이트
+        var waitingTotalPageCount = Math.ceil(waitingData.length / dmp_defVo.get("pageSize"));
+        pgl_defList_new.setCount(waitingTotalPageCount);
+        
+        
+        //진행중 그리드 업데이트
+        console.log("processingData",processingData)
+        dlt_processingList.setJSON(processingData);
+        spn_processingListCnt.setLabel(processingData.length)
+
+        //진행중 그리드 네비게이터 업데이트
+        var processingTotalPageCount = Math.ceil(processingData.length / dmp_defVo.get("pageSize"));
+        pgl_defList_processing.setCount(processingTotalPageCount);
+
+
+        //완료 그리드 업데이트
+        console.log("completedData",completedData)
+        dlt_completedList.setJSON(completedData);
+        spn_completeListCnt.setLabel(completedData.length)
+
+        //완료 그리드 네비게이터 업데이트
+        var completedTotalPageCount = Math.ceil(completedData.length / dmp_defVo.get("pageSize"));
+        pgl_defList_completed.setCount(completedTotalPageCount);
+
+		// 테스트결함관리 dataMap 초기화
+		dmp_defVoDetail.setEmptyValue();
+		
+		// 테스트결함관리 readOnly false
+		grp_defInfo.setReadOnly(false);
+		
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거		
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_defVoList.setJSON(elData.defVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_defVo.get("pageSize"));
+        pgl_defList.setCount(totalPageCount);
+        
+        spn_registerFlag.setValue("등록");
+
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_defVo.get("pageIndex"));
+        pgl_defList.setSelectedIndex(dmp_defVo.get("pageIndex"));
+	};	
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_defList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_defVo.set("pageIndex", idx);
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//dmp_defVo.set("pageSize", sel_pageSize.getValue());
+		 
+		// 서버통신 - 테스트결함관리 조회
+		$c.sbm.execute($p, sbm_selectDefVoList);
+	};
+
+	// 테스트결함관리 clear
+	scwin.btn_reset_onclick = function(e) {
+	
+		// 테스트결함관리 dataMap 초기화
+		dmp_defVoDetail.setEmptyValue();
+		// 테스트결함관리 readOnly false
+		grp_defInfo.setReadOnly(false);
+
+		btn_save.show("");   // 저장 버튼 생성
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		spn_registerFlag.setValue("등록");
+	};
+
+	/**
+	 * 그리드 셀 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.grd_list_oncellclick = function(row,col,colId) {
+
+		dmp_defVoDetail.setJSON(dlt_defVoList.getRowJSON(row));
+
+		btn_save.hide(); 		// 저장 버튼 제거
+		btn_edit.show("");      // 수정 버튼 생성
+		btn_delete.show("");    // 삭제 버튼 생성
+		
+		spn_registerFlag.setValue("수정");
+	};
+
+	/**
+	 * 저장 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */	
+	scwin.btn_save_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_defInfo, valInfo) === true) {
+			var promise = $c.win.confirm("저장하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_insertDefVo);
+				}
+			})
+		} 	
+	};
+
+	/**
+	 * 사원정보 등록 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_insertDefVo_submitdone = function(e) {
+		
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 등록되었습니다. msg 출력
+			$c.win.alert("등록되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 수정 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_edit_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_defInfo, valInfo) === true) {
+			var promise = $c.win.confirm("수정하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_updateDefVo);
+				}
+			})
+		} 
+	};
+
+	/**
+	 * 사원정보 수정 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_updateDefVo_submitdone = function(e) {
+
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 수정되었습니다. msg 출력
+			$c.win.alert("수정되었습니다.");
+		}
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 삭제 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_delete_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_defInfo, valInfo) === true) {
+			var promise = $c.win.confirm("삭제하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_deleteDefVo);
+				}
+			})
+		}	
+	};
+
+	/**
+	 * 삭제 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_deleteDefVo_submitdone = function(e) {
+	
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 삭제되었습니다. msg 출력
+			$c.win.alert("삭제되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+
+scwin.reg_btn_onclick = function (e) {
+    popup_reg.show();
+};
+
+scwin.reg_esc_btn_onclick = function (e) {
+    popup_reg.hide();
+};
+
+scwin.detail_esc_btn_onclick = function (e) {
+    popup_detail.hide();   
+};
+
+scwin.grd_list_onrenderrow = function(rowIndex) {
+    var statusValue = dlt_defVoList.getCellData(rowIndex, "status");
+    var cell = grd_list.getCell(rowIndex, "status");
+    
+    // 기존 텍스트 지우기
+    cell.innerHTML = "";
+    
+    // 상태에 따른 span 생성
+    var spanHtml = "";
+    switch(statusValue) {
+        case "NEW":
+            spanHtml = '<span style="background: #e6f3ff; color: #0066cc; padding: 2px 5px; border: 1px solid #b3d9ff; font-size: 10px; margin-right: 5px;">NEW</span>';
+            break;
+        case "PROG":
+            spanHtml = '<span style="background: #fff2e6; color: #cc6600; padding: 2px 5px; border: 1px solid #ffcc99; font-size: 10px; margin-right: 5px;">PROG</span>';
+            break;
+        case "FIX":
+            spanHtml = '<span style="background: #e6ffe6; color: #009900; padding: 2px 6px; border: 1px solid #99ff99; font-size: 10px; font-weight: bold; margin-right: 5px;">FIX</span>';
+            break;
+        case "REO":
+            spanHtml = '<span style="background: #ffe6f2; color: #cc0066; padding: 2px 6px; border: 1px solid #ff99cc; font-size: 10px; font-weight: bold; margin-right: 5px;">REO</span>';
+            break;
+        case "CLS":
+            spanHtml = '<span style="background: #f2e6ff; color: #6600cc; padding: 2px 6px; border: 1px solid #cc99ff; font-size: 10px; font-weight: bold; margin-right: 5px;">CLS</span>';
+            break;
+        default:
+            spanHtml = statusValue;
+    }
+    
+    cell.innerHTML = spanHtml;
+};
+
+
+
+scwin.new_grd_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    dmp_defVoDetail.setJSON(dlt_waitingList.getRowJSON(rowIndex));
+    popup_detail.show();   
+};
+
+scwin.processing_grd_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    dmp_defVoDetail.setJSON(dlt_processingList.getRowJSON(rowIndex));
+    popup_detail.show();   
+};
+
+scwin.complete_grd_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    dmp_defVoDetail.setJSON(dlt_completedList.getRowJSON(rowIndex));
+    popup_detail.show();   
+};
+
+scwin.processing_grd_onrenderrow = function(rowIndex) {
+    var priorityValue = dlt_waitingList.getCellData(rowIndex, "priority");
+    var cell = new_grd.getCell(rowIndex, "priority");
+    
+    if (!cell) return;
+    
+    // 우선순위에 따른 스타일 적용
+    var spanHtml = "";
+    
+    if(priorityValue === "CR" || priorityValue === "긴급") {
+        spanHtml = '<span style="background: #ffe6e6; color: #cc0000; padding: 2px 6px; border: 1px solid #ff9999; font-size: 10px; font-weight: bold; margin-right: 5px; border-radius: 3px;">긴급</span>';
+    } else if(priorityValue === "HI" || priorityValue === "높음") {
+        spanHtml = '<span style="background: #fff2e6; color: #cc6600; padding: 2px 6px; border: 1px solid #ffcc99; font-size: 10px; font-weight: bold; margin-right: 5px; border-radius: 3px;">높음</span>';
+    } else if(priorityValue === "MD" || priorityValue === "보통") {
+        spanHtml = '<span style="background: #e6f3ff; color: #0066cc; padding: 2px 6px; border: 1px solid #b3d9ff; font-size: 10px; margin-right: 5px; border-radius: 3px;">보통</span>';
+    } else if(priorityValue === "LO" || priorityValue === "낮음") {
+        spanHtml = '<span style="background: #f5f5f5; color: #666666; padding: 2px 6px; border: 1px solid #cccccc; font-size: 10px; margin-right: 5px; border-radius: 3px;">낮음</span>';
+    } else {
+        spanHtml = '<span style="background: #f0f0f0; color: #333333; padding: 2px 6px; border: 1px solid #cccccc; font-size: 10px; margin-right: 5px; border-radius: 3px;">' + priorityValue + '</span>';
+    }
+    
+    cell.innerHTML = spanHtml;
+};]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="테스트결함관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+
+							</xf:group>
+							<!-- 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제-->
+							<!--xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox id="" label="페이지 크기" localeRef="COMMON_LABEL_00001" ref="" style="" userData2=""></w2:textbox>
+								</xf:group>
+								<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:select1 allOption="" appearance="minimal" chooseOption="" direction="auto" disabled="false"
+								disabledClass="w2selectbox_disabled" id="sel_pageSize" ref="data:dmp_defVo.pageSize" renderType="native"
+								style="width: 80px;" submenuSize="auto" useItemLocale="false">
+								<xf:choices>
+								<xf:item>
+								<xf:label><![CDATA[5]]></xf:label>
+								<xf:value><![CDATA[5]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[10]]></xf:label>
+								<xf:value><![CDATA[10]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[20]]></xf:label>
+								<xf:value><![CDATA[20]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[30]]></xf:label>
+								<xf:value><![CDATA[30]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[50]]></xf:label>
+								<xf:value><![CDATA[50]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[100]]></xf:label>
+								<xf:value><![CDATA[100]]></xf:value>
+								</xf:item>
+								</xf:choices>
+								</xf:select1>
+								</xf:group-->
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button"
+						ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+					<xf:trigger class="" disabled="" escape="false" id="reg_btn" localeRef="COMMON_BUTTON_00001"
+						style="background: linear-gradient(to bottom, #5cb85c 0%, #449d44 100%); color: white; border: 1px solid #4cae4c; padding: 8px 16px; font-size: 12px;  height: 30px; border-radius: 3px; cursor: pointer; font-family: 'Malgun Gothic', sans-serif; min-width: 70px; box-shadow: 0 1px 2px rgba(0,0,0,0.2);border-radius: 4px;"
+						type="button" ev:onclick="scwin.reg_btn_onclick">
+						<xf:label><![CDATA[등록]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_defVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true" ev:oncelldblclick="scwin.grd_list_oncelldblclick">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" localeRef="Def_COLNAME_00001" inputType="text" id="column1" value="결함 고유 ID"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column64" value="연결된 테스트 ID" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="column13" value="테스트 케이스명" displayMode="label"></w2:column>
+							<w2:column width="70" localeRef="Def_COLNAME_00003" inputType="text" id="column3" value="결함명"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column15" value="결함 상세 설명" displayMode="label"></w2:column>
+							<w2:column width="70" localeRef="Def_COLNAME_00005" inputType="text" id="column5"
+								value="우선순위 (Critical/High/Medium/Low)" displayMode="label">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column69" value="상태 (신규/진행중/수정완료/재오픈/종료)"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" localeRef="Def_COLNAME_00007" inputType="text" id="column7" value="등록일시"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column72" value="수정 담당자" displayMode="label"></w2:column>
+							<w2:column width="70" localeRef="Def_COLNAME_00009" inputType="text" id="column9" value="수정 기한"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" localeRef="Def_COLNAME_00010" inputType="text" id="column10" value="수정 완료일"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" localeRef="Def_COLNAME_00011" inputType="text" id="column11" value="비고사항"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column76" value="삭제 여부" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" id="id" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="testId" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="testName" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" id="name" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="description" value="" displayMode="label"></w2:column>
+							<w2:column ref="" chooseOption="" width="70" inputType="select" id="priority" allOption=""
+								displayMode="label">
+								<w2:choices>
+									<w2:itemset nodeset="data:dlt_priority">
+										<w2:label ref="priority"></w2:label>
+										<w2:value ref="code"></w2:value>
+									</w2:itemset>
+								</w2:choices>
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="status" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" id="createdAt" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="userName" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" id="fixDueDate" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" id="fixedDate" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" id="remarks" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="isDeleted" value="" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_defList" pageSize="5" pagingType="0" style=""
+					ev:onclick="scwin.pgl_defList_onclick">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_defVo.pageIndex" style=""></w2:span>
+					<w2:span id="span1" label="/" style=""></w2:span>
+					<w2:span id="spn_totalPageCount" label="0" ref="data:dma_defVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group class="tblbox" id="grp_defInfo" style=""></xf:group>
+			<xf:group class="pop_contents" id="popup_detail" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+				meta_snippetName="0_02 팝업페이지시작"
+				style="position: fixed;top: 0;left: 0;width: 100%;height: 100%;background: rgba(0,0,0,0.5);z-index: 1000;display: none;">
+				<xf:group class="pop_contents" id="popup_grp" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+					meta_snippetName="0_02 팝업페이지시작"
+					style="background-color : white; position: relative;  top: 50%;  left: 50%;  transform: translate(-50%, -50%);  background: white;  padding: 20px;  border-radius: 8px;  max-width: 50%;  border : 1px solid grey;">
+					<xf:group class="titbox" id="" style="">
+						<xf:group id="" style="" tagname="h3">
+							<w2:textbox class="" id="" label="테스트결함관리" localeRef="" style=""></w2:textbox>
+							<w2:textbox class="" id="" label="(" style=""></w2:textbox>
+							<w2:textbox class="" id="textbox1" label="등록" localeRef="COMMON_LABEL_00006" style=""></w2:textbox>
+							<w2:textbox class="" id="" label=")" style=""></w2:textbox>
+						</xf:group>
+						<xf:group class="rt" id="" style="">
+							<xf:trigger class="btn_cm refresh" ev:onclick="scwin.btn_reset_onclick" id="trigger1"
+								localeRef="COMMON_BUTTON_00002" style="" type="button">
+								<xf:label><![CDATA[초기화]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_save_onclick" id="trigger2"
+								localeRef="COMMON_BUTTON_00003" style="" type="button">
+								<xf:label><![CDATA[저장]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_edit_onclick" id="trigger3"
+								localeRef="COMMON_BUTTON_00003" style="" type="button">
+								<xf:label><![CDATA[저장]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm delete" ev:onclick="scwin.btn_delete_onclick" id="trigger4"
+								localeRef="COMMON_BUTTON_00004" style="" type="button">
+								<xf:label><![CDATA[삭제]]></xf:label>
+							</xf:trigger>
+						</xf:group>
+						<xf:trigger anchorWithGroupClass="" class="btn_cm delete icon" id="detail_esc_btn" meta_snippetCategory="08_버튼"
+							meta_snippetKeyComponent="true" meta_snippetName="8_03 아이콘삭제버튼" style="" type="button" ev:onclick="scwin.detail_esc_btn_onclick">
+							<xf:label><![CDATA[Delete]]></xf:label>
+						</xf:trigger>
+					</xf:group>
+					<xf:group adaptive="layout" adaptiveThreshold="600" class="w2tb tbl" id="" style="" tagname="table">
+						<w2:attributes>
+							<w2:summary></w2:summary>
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							<xf:group style="width:150px;" tagname="col"></xf:group>
+							<xf:group style="" tagname="col"></xf:group>
+							<xf:group style="width:150px;" tagname="col"></xf:group>
+							<xf:group style="" tagname="col"></xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="결함 고유 ID" localeRef="Def_COLNAME_00001" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.id" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="연결된 테스트 ID" localeRef="Def_COLNAME_00002" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.testId" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="결함명" localeRef="Def_COLNAME_00003" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.name" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="결함 상세 설명" localeRef="Def_COLNAME_00004" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.description" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="우선순위" localeRef="Def_COLNAME_00005" ref="" style="" userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.priority" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="상태" localeRef="Def_COLNAME_00006" ref="" style="" userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.status" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="등록일시" localeRef="Def_COLNAME_00007" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.createdAt" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="수정 담당자" localeRef="Def_COLNAME_00008" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.assignee" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="수정 기한" localeRef="Def_COLNAME_00009" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.fixDueDate" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="수정 완료일" localeRef="Def_COLNAME_00010" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.fixedDate" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="비고사항" localeRef="Def_COLNAME_00011" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.remarks" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="삭제 여부" localeRef="Def_COLNAME_00012" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.isDeleted" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr"></xf:group>
+					</xf:group>
+				</xf:group>
+			</xf:group>
+			<xf:group tagname="table" style="margin-top : 20px;width: 50%;border: 0;" id="" class="w2tb">
+				<w2:attributes>
+					<w2:summary></w2:summary>
+				</w2:attributes>
+				<xf:group tagname="caption"></xf:group>
+				<xf:group tagname="colgroup">
+					<xf:group tagname="col" style="width:30px;"></xf:group>
+					<xf:group tagname="col" style="width:50px;"></xf:group>
+					<xf:group tagname="col" style="width:60px;"></xf:group>
+				</xf:group>
+				<xf:group tagname="tr" style="height:15px;;">
+					<xf:group tagname="td" style="" class="w2tb_td">
+						<w2:span id="" label="신규"
+							style="background: #e6f3ff; color: #0066cc; padding: 2px 5px; border: 1px solid #b3d9ff; font-size: 10px; margin-right: 5px;">
+						</w2:span>
+					</xf:group>
+					<xf:group tagname="td" style="" class="w2tb_td">신규</xf:group>
+					<xf:group tagname="td" style="" class="w2tb_td">신규&amp;nbsp;등록된&amp;nbsp;결함</xf:group>
+				</xf:group>
+				<xf:group tagname="tr" style="">
+					<xf:group tagname="td" style="" class="w2tb_td">
+						<w2:span id="" label="진행중"
+							style="background: #fff2e6; color: #cc6600; padding: 2px 5px; border: 1px solid #ffcc99; font-size: 10px; margin-right: 5px;">
+						</w2:span>
+					</xf:group>
+					<xf:group tagname="td" style="" class="w2tb_td">진행중</xf:group>
+					<xf:group tagname="td" style="" class="w2tb_td">수정&amp;nbsp;작업이&amp;nbsp;진행중인&amp;nbsp;상태</xf:group>
+				</xf:group>
+				<xf:group tagname="tr" style="">
+					<xf:group tagname="td" style="" class="w2tb_td">
+						<w2:span id="" label="완료"
+							style="background: #f2e6ff; color: #6600cc; padding: 2px 6px; border: 1px solid #cc99ff; font-size: 10px; font-weight: bold;">
+						</w2:span>
+					</xf:group>
+					<xf:group tagname="td" style="" class="w2tb_td">완료</xf:group>
+					<xf:group tagname="td" style="" class="w2tb_td">
+						최종적으로&amp;nbsp;종료&amp;nbsp;완료된&amp;nbsp;상태
+						<br></br>
+					</xf:group>
+				</xf:group>
+			</xf:group>
+			<xf:group class="pop_contents" id="popup_reg" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+				meta_snippetName="0_02 팝업페이지시작"
+				style="position: fixed;top: 0;left: 0;width: 100%;height: 100%;background: rgba(0,0,0,0.5);z-index: 1000;display:none;">
+				<xf:group class="pop_contents" id="group2" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+					meta_snippetName="0_02 팝업페이지시작"
+					style="background-color : white; position: relative;  top: 50%;  left: 50%;  transform: translate(-50%, -50%);  background: white;  padding: 20px;  border-radius: 8px;  max-width: 50%;  border : 1px solid grey;">
+					<xf:group class="titbox" id="" style="">
+						<xf:group id="" style="" tagname="h3">
+							<w2:textbox class="" id="" label="테스트결함관리" localeRef="" style=""></w2:textbox>
+							<w2:textbox class="" id="" label="(" style=""></w2:textbox>
+							<w2:textbox class="" id="textbox2" label="등록" localeRef="COMMON_LABEL_00006" style=""></w2:textbox>
+							<w2:textbox class="" id="" label=")" style=""></w2:textbox>
+						</xf:group>
+						<xf:group class="rt" id="" style="">
+							<xf:trigger class="btn_cm refresh" ev:onclick="scwin.btn_reset_onclick" id="trigger6"
+								localeRef="COMMON_BUTTON_00002" style="" type="button">
+								<xf:label><![CDATA[초기화]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_save_onclick" id="trigger7"
+								localeRef="COMMON_BUTTON_00003" style="" type="button">
+								<xf:label><![CDATA[저장]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_edit_onclick" id="trigger8"
+								localeRef="COMMON_BUTTON_00003" style="" type="button">
+								<xf:label><![CDATA[저장]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm delete" ev:onclick="scwin.btn_delete_onclick" id="trigger9"
+								localeRef="COMMON_BUTTON_00004" style="" type="button">
+								<xf:label><![CDATA[삭제]]></xf:label>
+							</xf:trigger>
+						</xf:group>
+						<xf:trigger anchorWithGroupClass="" class="btn_cm delete icon" id="reg_esc_btn" meta_snippetCategory="08_버튼"
+							meta_snippetKeyComponent="true" meta_snippetName="8_03 아이콘삭제버튼" style="" type="button" ev:onclick="scwin.reg_esc_btn_onclick">
+							<xf:label><![CDATA[Delete]]></xf:label>
+						</xf:trigger>
+					</xf:group>
+					<xf:group adaptive="layout" adaptiveThreshold="600" class="w2tb tbl" id="" style="" tagname="table">
+						<w2:attributes>
+							<w2:summary></w2:summary>
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							<xf:group style="width:150px;" tagname="col"></xf:group>
+							<xf:group style="" tagname="col"></xf:group>
+							<xf:group style="width:150px;" tagname="col"></xf:group>
+							<xf:group style="" tagname="col"></xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="결함 고유 ID" localeRef="Def_COLNAME_00001" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="연결된 테스트 ID" localeRef="Def_COLNAME_00002" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="결함명" localeRef="Def_COLNAME_00003" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="담당자" localeRef="Def_COLNAME_00008" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="우선순위" localeRef="Def_COLNAME_00005" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:select1 allOption="" appearance="minimal" chooseOption="true" direction="auto" disabled="false"
+									disabledClass="w2selectbox_disabled" id="" style="width: 148px;height: 21px;" submenuSize="auto" ref=""
+									chooseOptionLabel="$blank">
+									<xf:choices>
+										<xf:itemset nodeset="data:dlt_priority">
+											<xf:label ref="priority"></xf:label>
+											<xf:value ref="code"></xf:value>
+										</xf:itemset>
+									</xf:choices>
+								</xf:select1>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="상태" localeRef="Def_COLNAME_00006" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:select1 id="" chooseOption="true" style="width: 148px;height: 21px;" submenuSize="auto" allOption=""
+									disabled="false" direction="auto" appearance="minimal" disabledClass="w2selectbox_disabled" chooseOptionLabel="$blank" ref="">
+									<xf:choices>
+										<xf:itemset nodeset="data:dlt_status">
+											<xf:label ref="status"></xf:label>
+											<xf:value ref="code"></xf:value>
+										</xf:itemset>
+									</xf:choices>
+								</xf:select1>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="등록일시" localeRef="Def_COLNAME_00007" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="수정 기한" localeRef="Def_COLNAME_00009" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<w2:inputCalendar id="" style="width: 150px;height: 23px;" calendarValueType="yearMonthDate"></w2:inputCalendar>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="수정 완료일" localeRef="Def_COLNAME_00010" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<w2:inputCalendar calendarValueType="yearMonthDate" id="" style="width: 150px;height: 23px;"></w2:inputCalendar>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="비고사항" localeRef="Def_COLNAME_00011" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_defVoDetail.remarks" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr"></xf:group>
+						<xf:group style="" tagname="tr"></xf:group>
+						<xf:group style="" tagname="tr"></xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="결함 상세 설명" localeRef="Def_COLNAME_00004" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+				</xf:group>
+			</xf:group>
+
+
+			<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+				style="padding:5px;">
+				<w2:textbox class="" id="" label="신규" style="" tagname="h4"></w2:textbox>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_waitListCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+			<xf:group id="">
+				<w2:gridView scrollByColumnAdaptive="false" readOnly="true" scrollByColumn="false" defaultCellHeight="26"
+					checkReadOnlyOnPasteEnable="" focusMode="row" dataList="data:dlt_waitingList" style="height: 150px;" autoFit="allColumn" id="new_grd"
+					visibleRowNum="10" class="gvw" ev:oncelldblclick="scwin.new_grd_oncelldblclick">
+					<w2:caption style="" id="caption4" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header_new">
+						<w2:row style="" id="row_new">
+							<w2:column width="100" inputType="text" id="column1" value="결함 고유 ID" displayMode="label"></w2:column>
+							<w2:column width="250" inputType="text" id="column2" value="테스트 케이스명" displayMode="label"></w2:column>
+							<w2:column width="200" inputType="text" id="column3" value="결함명" displayMode="label"></w2:column>
+							<w2:column width="100" inputType="text" id="column4" value="우선순위"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="150" inputType="text" id="column5" value="등록일시" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="column46" value="수정 담당자" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="column7" value="수정 기한" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="column8" value="수정 완료일" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:header>
+
+					<w2:gBody style="" id="gBody_new">
+						<w2:row style="" id="row_new_body">
+							<w2:column width="100" inputType="text" id="id" displayMode="label"></w2:column>
+							<w2:column width="250" inputType="text" id="testName" displayMode="label"></w2:column>
+							<w2:column width="200" inputType="text" id="name" displayMode="label"></w2:column>
+							<w2:column ref="" chooseOption="" width="100" inputType="select" id="priority" allOption=""
+								displayMode="label">
+								<w2:choices>
+									<w2:itemset nodeset="data:dlt_priority">
+										<w2:label ref="priority"></w2:label>
+										<w2:value ref="code"></w2:value>
+									</w2:itemset>
+								</w2:choices>
+							</w2:column>
+							<w2:column width="150" inputType="text" id="createdAt" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="userName" value="" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="fixDueDate" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="fixedDate" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView></xf:group></xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" ev:onclick="scwin.pgl_defList_onclick" id="pgl_defList_new"
+					pageSize="5" pagingType="0" style="">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="span14" label="0" ref="data:dma_defVo.pageIndex" style=""></w2:span>
+					<w2:span id="span15" label="/" style=""></w2:span>
+					<w2:span id="span16" label="0" ref="data:dma_defVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span17" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			
+            
+            <xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+				style="padding:5px;">
+				<w2:textbox class="" id="" label="진행중" style="" tagname="h4"></w2:textbox>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_processingListCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_processingList"
+					defaultCellHeight="26" focusMode="row" id="processing_grd" readOnly="true" scrollByColumn="false" scrollByColumnAdaptive="false"
+					style="height: 150px;" visibleRowNum="10" ev:oncelldblclick="scwin.processing_grd_oncelldblclick">
+					<w2:caption id="caption5" style="" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header_processing">
+						<w2:row style="" id="row_processing">
+							<w2:column width="100" inputType="text" id="column1" value="결함 고유 ID" displayMode="label"></w2:column>
+							<w2:column width="250" inputType="text" id="column2" value="테스트 케이스명" displayMode="label"></w2:column>
+							<w2:column width="200" inputType="text" id="column3" value="결함명" displayMode="label"></w2:column>
+							<w2:column width="100" inputType="text" id="column4" value="우선순위"
+								displayMode="label">
+							</w2:column>
+							<w2:column width="150" inputType="text" id="column5" value="등록일시" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="column46" value="수정 담당자" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="column7" value="수정 기한" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="column8" value="수정 완료일" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:header>
+
+					<w2:gBody style="" id="gBody_processing">
+						<w2:row style="" id="row_processing_body">
+							<w2:column width="100" inputType="text" id="id" displayMode="label"></w2:column>
+							<w2:column width="250" inputType="text" id="testName" displayMode="label"></w2:column>
+							<w2:column width="200" inputType="text" id="name" displayMode="label"></w2:column>
+							<w2:column ref="" chooseOption="" width="100" inputType="span" id="priority" allOption="" displayMode="label">
+								<w2:choices>
+									<w2:itemset nodeset="data:dlt_priority">
+										<w2:label ref="priority"></w2:label>
+										<w2:value ref="code"></w2:value>
+									</w2:itemset>
+								</w2:choices>
+							</w2:column>
+							<w2:column width="150" inputType="text" id="createdAt" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="userName" value="" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="fixDueDate" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="fixedDate" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" ev:onclick="scwin.pgl_defList_onclick" id="pgl_defList_processing"
+					pageSize="5" pagingType="0" style="">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="span24" label="0" ref="data:dma_defVo.pageIndex" style=""></w2:span>
+					<w2:span id="span25" label="/" style=""></w2:span>
+					<w2:span id="span26" label="0" ref="data:dma_defVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span27" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+				style="padding:5px;">
+				<w2:textbox class="" id="" label="완료" style="" tagname="h4"></w2:textbox>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_completeListCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_completedList"
+					defaultCellHeight="26" focusMode="row" id="complete_grd" readOnly="true" scrollByColumn="false" scrollByColumnAdaptive="false"
+					style="height: 150px;" visibleRowNum="10" ev:oncelldblclick="scwin.complete_grd_oncelldblclick">
+					<w2:caption id="caption6" style="" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header_complete">
+                        <w2:row style="" id="row_complete">
+                            <w2:column width="100" inputType="text" id="column1" value="결함 고유 ID" displayMode="label"></w2:column>
+                            <w2:column width="250" inputType="text" id="column2" value="테스트 케이스명" displayMode="label"></w2:column>
+                            <w2:column width="200" inputType="text" id="column3" value="결함명" displayMode="label"></w2:column>
+                            <w2:column width="100" inputType="text" id="column4" value="우선순위" displayMode="label"></w2:column>
+                            <w2:column width="150" inputType="text" id="column5" value="등록일시" displayMode="label"></w2:column>
+                            <w2:column width="120" inputType="text" id="column6" value="수정 담당자" displayMode="label"></w2:column>
+                            <w2:column width="120" inputType="text" id="column7" value="수정 기한" displayMode="label"></w2:column>
+                            <w2:column width="120" inputType="text" id="column8" value="수정 완료일" displayMode="label"></w2:column>
+                        </w2:row>
+                    </w2:header>
+                    
+                    <w2:gBody style="" id="gBody_complete">
+                        <w2:row style="" id="row_complete_body">
+                            <w2:column width="100" inputType="text" id="id" displayMode="label"></w2:column>
+                            <w2:column width="250" inputType="text" id="testName" displayMode="label"></w2:column>
+                            <w2:column width="200" inputType="text" id="name" displayMode="label"></w2:column>
+                            <w2:column width="100" inputType="output" id="priority" displayMode="label">
+                                <!-- 긴급 (CR) - 빨간색 -->
+                                <w2:span id="spanCR_new" label="긴급"
+                                    style="background: #ffe6e6; color: #cc0000; padding: 2px 6px; border: 1px solid #ff9999; font-size: 10px; font-weight: bold; margin-right: 5px; border-radius: 3px;"
+                                    visibleExpression="priority == 'CR' || priority == '긴급'">
+                                </w2:span>
+                                
+                                <!-- 높음 (HI) - 주황색 -->
+                                <w2:span id="spanHI_new" label="높음"
+                                    style="background: #fff2e6; color: #cc6600; padding: 2px 6px; border: 1px solid #ffcc99; font-size: 10px; font-weight: bold; margin-right: 5px; border-radius: 3px;"
+                                    visibleExpression="priority == 'HI' || priority == '높음'">
+                                </w2:span>
+                                
+                                <!-- 보통 (MD) - 파란색 -->
+                                <w2:span id="spanMD_new" label="보통"
+                                    style="background: #e6f3ff; color: #0066cc; padding: 2px 6px; border: 1px solid #b3d9ff; font-size: 10px; margin-right: 5px; border-radius: 3px;"
+                                    visibleExpression="priority == 'MD' || priority == '보통'">
+                                </w2:span>
+                                
+                                <!-- 낮음 (LO) - 회색 -->
+                                <w2:span id="spanLO_new" label="낮음"
+                                    style="background: #f5f5f5; color: #666666; padding: 2px 6px; border: 1px solid #cccccc; font-size: 10px; margin-right: 5px; border-radius: 3px;"
+                                    visibleExpression="priority == 'LO' || priority == '낮음'">
+                                </w2:span>
+                                
+                                
+                            </w2:column>
+                            <w2:column width="150" inputType="text" id="createdAt" displayMode="label"></w2:column>
+                            <w2:column width="120" inputType="text" id="assignee" displayMode="label"></w2:column>
+                            <w2:column width="120" inputType="text" id="fixDueDate" displayMode="label"></w2:column>
+                            <w2:column width="120" inputType="text" id="fixedDate" displayMode="label"></w2:column>
+                        </w2:row>
+                    </w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" ev:onclick="scwin.pgl_defList_onclick" id="pgl_defList_completed"
+					pageSize="5" pagingType="0" style="">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="span34" label="0" ref="data:dma_defVo.pageIndex" style=""></w2:span>
+					<w2:span id="span35" label="/" style=""></w2:span>
+					<w2:span id="span36" label="0" ref="data:dma_defVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span37" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/def/DefList.xml
+++ b/src/main/webapp/ui/def/DefList.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_defVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지_번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지_건수" defaultValue="10"></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_defVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="결함 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="testId" name="연결된 테스트 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="결함명"></w2:column>
+                        <w2:column dataType="text" id="description" name="결함 상세 설명"></w2:column>
+                        <w2:column dataType="text" id="priority" name="우선순위 (Critical/High/Medium/Low)"></w2:column>
+                        <w2:column dataType="text" id="status" name="상태 (신규/진행중/수정완료/재오픈/종료)"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="assignee" name="수정 담당자"></w2:column>
+                        <w2:column dataType="text" id="fixDueDate" name="수정 기한"></w2:column>
+                        <w2:column dataType="text" id="fixedDate" name="수정 완료일"></w2:column>
+                        <w2:column dataType="text" id="remarks" name="비고사항"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_defVoDetail" style="">
+					<w2:keyInfo>
+						
+					</w2:keyInfo>
+				</w2:dataMap>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectDefVoList" ref='data:json,{"id":"dmp_defVo","key":"defVo"}'
+				target='data:json,{"id":"dlt_defVoList","key":"elData.defVoList"}' action="/InsWebApp/DEF001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="테스트결함관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_defList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 테스트결함관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_defVo.set("pageIndex","1");
+		pgl_defList.setSelectedIndex(1);
+
+		// 서버통신 - 테스트결함관리 조회
+		$c.sbm.execute($p, sbm_selectDefVoList);
+	};
+	
+	scwin.sbm_defList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+		// 테스트결함관리 dataMap 초기화
+		dmp_defVoDetail.setEmptyValue();
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_defVoList.setJSON(elData.defVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_defVo.get("pageSize"));
+        pgl_defList.setCount(totalPageCount);
+        
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_defVo.get("pageIndex"));
+        pgl_defList.setSelectedIndex(dmp_defVo.get("pageIndex"));
+	};		
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_defList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_defVo.set( "pageIndex" , idx ); 
+		// 서버통신 - 사원목록 조회
+		$c.sbm.execute($p, sbm_selectDefVoList);
+	};
+
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="테스트결함관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+								
+							</xf:group>
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button" ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+    				<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+    				<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+    			</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_defVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" inputType="text" style="" id="column1" value="결함 고유 ID" displayMode="label" localeRef="Def_COLNAME_00001"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column2" value="연결된 테스트 ID" displayMode="label" localeRef="Def_COLNAME_00002"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column3" value="결함명" displayMode="label" localeRef="Def_COLNAME_00003"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column4" value="결함 상세 설명" displayMode="label" localeRef="Def_COLNAME_00004"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column5" value="우선순위 (Critical/High/Medium/Low)" displayMode="label" localeRef="Def_COLNAME_00005"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column6" value="상태 (신규/진행중/수정완료/재오픈/종료)" displayMode="label" localeRef="Def_COLNAME_00006"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column7" value="등록일시" displayMode="label" localeRef="Def_COLNAME_00007"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column8" value="수정 담당자" displayMode="label" localeRef="Def_COLNAME_00008"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column9" value="수정 기한" displayMode="label" localeRef="Def_COLNAME_00009"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column10" value="수정 완료일" displayMode="label" localeRef="Def_COLNAME_00010"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column11" value="비고사항" displayMode="label" localeRef="Def_COLNAME_00011"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column12" value="삭제 여부" displayMode="label" localeRef="Def_COLNAME_00012"></w2:column>
+                           
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" style="" id="id" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="testId" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="name" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="description" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="priority" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="status" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="createdAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="assignee" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="fixDueDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="fixedDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="remarks" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="isDeleted" value="" displayMode="label"></w2:column>
+                           
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_defList" pageSize="5" pagingType="0"
+					style="" ev:onclick="scwin.pgl_defList_onclick">
+				</w2:pageList>	
+				<xf:group class="pgl_count" id="" style="display: none;">
+    				<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_defVo.pageIndex" style=""></w2:span>
+    				<w2:span id="span1" label="/" style=""></w2:span>
+    				<w2:span id="spn_totalPageCount" label="0" ref="data:dma_defVo.totalPageCount" style=""></w2:span>
+    				<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+    			</xf:group>		
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/iss/Iss.xml
+++ b/src/main/webapp/ui/iss/Iss.xml
@@ -1,0 +1,1035 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_issVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지사이즈" defaultValue="10"></w2:key>
+						<w2:key dataType="text" id="totalPageCount" name="페이지건수" ></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_issVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="id" name="이슈/리스크 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="이슈/리스크명"></w2:column>
+                        <w2:column dataType="text" id="userId" name="작성자 사용자 ID"></w2:column>
+                        <w2:column dataType="text" id="dueDate" name="완료 예정일"></w2:column>
+                        <w2:column dataType="text" id="status" name="상태 (해결 전, 해결 중, 해결 후)"></w2:column>
+                        <w2:column dataType="text" id="priority" name="우선순위 (높음, 중간, 낮음)"></w2:column>
+                        <w2:column dataType="text" id="type" name="타입 (이슈, 리스크, 테스트)"></w2:column>
+                        <w2:column dataType="text" id="description" name="상세 내용"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="resolvedDate" name="resolved_date"></w2:column>
+                        <w2:column dataType="text" id="responsePlan" name="response_plan"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="is_deleted"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_issVoDetail" style="">
+					<w2:keyInfo>
+						<w2:key dataType="text" id="pjtId" name="프로젝트 ID"></w2:key>
+                        <w2:key dataType="text" id="id" name="이슈/리스크 고유 ID"></w2:key>
+                        <w2:key dataType="text" id="name" name="이슈/리스크명"></w2:key>
+                        <w2:key dataType="text" id="userId" name="작성자 사용자 ID"></w2:key>
+                        <w2:key dataType="text" id="dueDate" name="완료 예정일"></w2:key>
+                        <w2:key dataType="text" id="status" name="상태 (해결 전, 해결 중, 해결 후)"></w2:key>
+                        <w2:key dataType="text" id="priority" name="우선순위 (높음, 중간, 낮음)"></w2:key>
+                        <w2:key dataType="text" id="type" name="타입 (이슈, 리스크, 테스트)"></w2:key>
+                        <w2:key dataType="text" id="description" name="상세 내용"></w2:key>
+                        <w2:key dataType="text" id="createdAt" name="등록일시"></w2:key>
+                        <w2:key dataType="text" id="updatedAt" name="수정일시"></w2:key>
+                        <w2:key dataType="text" id="resolvedDate" name="resolved_date"></w2:key>
+                        <w2:key dataType="text" id="responsePlan" name="response_plan"></w2:key>
+                        <w2:key dataType="text" id="isDeleted" name="is_deleted"></w2:key>
+                       
+					</w2:keyInfo>
+				</w2:dataMap>
+                <w2:dataList baseNode="list" id="dlt_waitingList" repeatNode="map" saveRemovedData="true" style="">
+                    <w2:columnInfo>
+                        <w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="id" name="이슈/리스크 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="이슈/리스크명"></w2:column>
+                        <w2:column dataType="text" id="userId" name="작성자 사용자 ID"></w2:column>
+                        <w2:column dataType="text" id="dueDate" name="완료 예정일"></w2:column>
+                        <w2:column dataType="text" id="status" name="상태 (해결 전, 해결 중, 해결 후)"></w2:column>
+                        <w2:column dataType="text" id="priority" name="우선순위 (높음, 중간, 낮음)"></w2:column>
+                        <w2:column dataType="text" id="type" name="타입 (이슈, 리스크, 테스트)"></w2:column>
+                        <w2:column dataType="text" id="description" name="상세 내용"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="resolvedDate" name="resolved_date"></w2:column>
+                        <w2:column dataType="text" id="responsePlan" name="response_plan"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="is_deleted"></w2:column>
+                    </w2:columnInfo>
+                </w2:dataList>
+
+                <w2:dataList baseNode="list" id="dlt_processingList" repeatNode="map" saveRemovedData="true" style="">
+                    <w2:columnInfo>
+                        <w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="id" name="이슈/리스크 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="이슈/리스크명"></w2:column>
+                        <w2:column dataType="text" id="userId" name="작성자 사용자 ID"></w2:column>
+                        <w2:column dataType="text" id="dueDate" name="완료 예정일"></w2:column>
+                        <w2:column dataType="text" id="status" name="상태 (해결 전, 해결 중, 해결 후)"></w2:column>
+                        <w2:column dataType="text" id="priority" name="우선순위 (높음, 중간, 낮음)"></w2:column>
+                        <w2:column dataType="text" id="type" name="타입 (이슈, 리스크, 테스트)"></w2:column>
+                        <w2:column dataType="text" id="description" name="상세 내용"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="resolvedDate" name="resolved_date"></w2:column>
+                        <w2:column dataType="text" id="responsePlan" name="response_plan"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="is_deleted"></w2:column>
+                    </w2:columnInfo>
+                </w2:dataList>
+
+                <w2:dataList baseNode="list" id="dlt_completedList" repeatNode="map" saveRemovedData="true" style="">
+                    <w2:columnInfo>
+                        <w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="id" name="이슈/리스크 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="이슈/리스크명"></w2:column>
+                        <w2:column dataType="text" id="userId" name="작성자 사용자 ID"></w2:column>
+                        <w2:column dataType="text" id="dueDate" name="완료 예정일"></w2:column>
+                        <w2:column dataType="text" id="status" name="상태 (해결 전, 해결 중, 해결 후)"></w2:column>
+                        <w2:column dataType="text" id="priority" name="우선순위 (높음, 중간, 낮음)"></w2:column>
+                        <w2:column dataType="text" id="type" name="타입 (이슈, 리스크, 테스트)"></w2:column>
+                        <w2:column dataType="text" id="description" name="상세 내용"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="resolvedDate" name="resolved_date"></w2:column>
+                        <w2:column dataType="text" id="responsePlan" name="response_plan"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="is_deleted"></w2:column>
+                    </w2:columnInfo>
+                </w2:dataList>
+
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectIssVoList" ref='data:json,{"id":"dmp_issVo","key":"issVo"}'
+				target='data:json,{"id":"dlt_issVoList","key":"elData.issVoList"}' action="/InsWebApp/ISS001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="이슈리스크관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_issList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_deleteIssVo" ref='data:json,{"id":"dmp_issVoDetail","key":"issVo"}' target="" action="/InsWebApp/ISS001Del.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_deleteIssVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_updateIssVo" ref='data:json,["dmp_issVoDetail",{"id":"dmp_issVoDetail","key":"issVo"}]' target="" action="/InsWebApp/ISS001Upd.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_updateIssVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_insertIssVo" ref='data:json,["dmp_issVoDetail",{"id":"dmp_issVoDetail","key":"issVo"}]' target="" action="/InsWebApp/ISS001Ins.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_insertIssVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_selectIssVo" ref="" target="" action="/InsWebApp/ISS001UpdView.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="이슈리스크관리를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_selectIssVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {
+		// 이슈리스크관리 readOnly false
+		
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼 
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//sel_pageSize.setValue("10");
+		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 이슈리스크관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_issVo.set("pageIndex","1");
+		pgl_issList.setSelectedIndex(1);
+
+		// 서버통신 - 이슈리스크관리 조회
+		$c.sbm.execute($p, sbm_selectIssVoList);
+	};
+	
+	scwin.sbm_issList_submitdone = function(e) {
+        // error 수신시
+        var elData = e.responseJSON.elData;
+        var elHeader  = e.responseJSON.elHeader;
+        if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+            $c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+            return false;
+        }
+
+        // status별로 데이터 필터링
+        var allData = elData.issVoList || [];
+        var waitingData = [];    // PEN - 대기
+        var processingData = []; // IPR - 진행중
+        var completedData = [];  // COM - 완료
+
+        console.log("allData",allData)
+
+
+        // 데이터 분류
+        for(var i = 0; i < allData.length; i++) {
+            var item = allData[i];
+            if(item.status === "PEN") {
+                waitingData.push(item);
+            } else if(item.status === "IPR") {
+                processingData.push(item);
+            } else if(item.status === "COM") {
+                completedData.push(item);
+            }
+        }
+    
+        console.log("waitingData",waitingData)
+        dlt_waitingList.setJSON(waitingData);
+        spn_waitListCnt.setLabel(waitingData.length)
+        
+        console.log("processingData",processingData)
+        dlt_processingList.setJSON(processingData);
+        spn_processingListCnt.setLabel(processingData.length)
+
+        console.log("completedData",completedData)
+        dlt_completedList.setJSON(completedData);
+        spn_completeListCnt.setLabel(completedData.length)
+        
+        // 이슈리스크관리 dataMap 초기화
+        dmp_issVoDetail.setEmptyValue();
+        
+        // 이슈리스크관리 readOnly false
+        grp_issInfo.setReadOnly(false);
+        
+        // 버튼 숨김
+        btn_save.show("");   // 저장 버튼
+        btn_edit.hide();     // 수정 버튼 제거
+        btn_delete.hide();   // 삭제 버튼 제거		
+
+        // 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 전체 데이터를 그리드에 셋팅
+        dlt_issVoList.setJSON(elData.issVoList);
+                            
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_issVo.get("pageSize"));
+        pgl_issList.setCount(totalPageCount);
+        
+        spn_registerFlag.setValue("등록");
+
+        // 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_issVo.get("pageIndex"));
+        pgl_issList.setSelectedIndex(dmp_issVo.get("pageIndex"));
+    };
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_issList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_issVo.set("pageIndex", idx);
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//dmp_issVo.set("pageSize", sel_pageSize.getValue());
+		 
+		// 서버통신 - 이슈리스크관리 조회
+		$c.sbm.execute($p, sbm_selectIssVoList);
+	};
+
+	// 이슈리스크관리 clear
+	scwin.btn_reset_onclick = function(e) {
+	
+		// 이슈리스크관리 dataMap 초기화
+		dmp_issVoDetail.setEmptyValue();
+		// 이슈리스크관리 readOnly false
+		grp_issInfo.setReadOnly(false);
+
+		btn_save.show("");   // 저장 버튼 생성
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		spn_registerFlag.setValue("등록");
+	};
+
+	/**
+	 * 그리드 셀 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.grd_list_oncellclick = function(row,col,colId) {
+
+		dmp_issVoDetail.setJSON(dlt_issVoList.getRowJSON(row));
+
+		btn_save.hide(); 		// 저장 버튼 제거
+		btn_edit.show("");      // 수정 버튼 생성
+		btn_delete.show("");    // 삭제 버튼 생성
+		
+		spn_registerFlag.setValue("수정");
+	};
+
+	/**
+	 * 저장 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */	
+	scwin.btn_save_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_issInfo, valInfo) === true) {
+			var promise = $c.win.confirm("저장하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_insertIssVo);
+				}
+			})
+		} 	
+	};
+
+	/**
+	 * 사원정보 등록 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_insertIssVo_submitdone = function(e) {
+		
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 등록되었습니다. msg 출력
+			$c.win.alert("등록되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 수정 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_edit_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_issInfo, valInfo) === true) {
+			var promise = $c.win.confirm("수정하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_updateIssVo);
+				}
+			})
+		} 
+	};
+
+	/**
+	 * 사원정보 수정 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_updateIssVo_submitdone = function(e) {
+
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 수정되었습니다. msg 출력
+			$c.win.alert("수정되었습니다.");
+		}
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 삭제 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_delete_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_issInfo, valInfo) === true) {
+			var promise = $c.win.confirm("삭제하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_deleteIssVo);
+				}
+			})
+		}	
+	};
+
+	/**
+	 * 삭제 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_deleteIssVo_submitdone = function(e) {
+	
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 삭제되었습니다. msg 출력
+			$c.win.alert("삭제되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+scwin.waiting_grd_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    dmp_issVoDetail.setJSON(dlt_waitingList.getRowJSON(rowIndex));
+    pop_overlay.show();
+};
+
+scwin.detail_esc_btn_onclick = function (e) {
+    pop_overlay.hide();
+};
+
+scwin.processing_grd_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    dmp_issVoDetail.setJSON(dlt_processingList.getRowJSON(rowIndex));
+    pop_overlay.show();
+};
+
+scwin.complete_grd_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    dmp_issVoDetail.setJSON(dlt_completedList.getRowJSON(rowIndex));
+    pop_overlay.show();
+};
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="이슈리스크관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+
+							</xf:group>
+							<!-- 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제-->
+							<!--xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox id="" label="페이지 크기" localeRef="COMMON_LABEL_00001" ref="" style="" userData2=""></w2:textbox>
+								</xf:group>
+								<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:select1 allOption="" appearance="minimal" chooseOption="" direction="auto" disabled="false"
+								disabledClass="w2selectbox_disabled" id="sel_pageSize" ref="data:dmp_issVo.pageSize" renderType="native"
+								style="width: 80px;" submenuSize="auto" useItemLocale="false">
+								<xf:choices>
+								<xf:item>
+								<xf:label><![CDATA[5]]></xf:label>
+								<xf:value><![CDATA[5]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[10]]></xf:label>
+								<xf:value><![CDATA[10]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[20]]></xf:label>
+								<xf:value><![CDATA[20]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[30]]></xf:label>
+								<xf:value><![CDATA[30]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[50]]></xf:label>
+								<xf:value><![CDATA[50]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[100]]></xf:label>
+								<xf:value><![CDATA[100]]></xf:value>
+								</xf:item>
+								</xf:choices>
+								</xf:select1>
+								</xf:group-->
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button"
+						ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+					<xf:trigger class="" disabled="" escape="false" ev:onclick="scwin.btn_search_onclick" id="trigger5"
+						localeRef="COMMON_BUTTON_00001"
+						style="background: linear-gradient(to bottom, #5cb85c 0%, #449d44 100%); color: white; border: 1px solid #4cae4c; padding: 8px 16px; font-size: 12px;  height: 30px; border-radius: 3px; cursor: pointer; font-family: 'Malgun Gothic', sans-serif; min-width: 70px; box-shadow: 0 1px 2px rgba(0,0,0,0.2);border-radius: 4px;"
+						type="button">
+						<xf:label><![CDATA[등록]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_issVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true" ev:oncelldblclick="scwin.grd_list_oncelldblclick">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" inputType="text" style="" id="column2" value="프로젝트 ID" displayMode="label"
+								localeRef="Iss_COLNAME_00002">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column3" value="이슈/리스크 고유 ID" displayMode="label"
+								localeRef="Iss_COLNAME_00003">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column4" value="이슈/리스크명" displayMode="label"
+								localeRef="Iss_COLNAME_00004">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column5" value="작성자 사용자 ID" displayMode="label"
+								localeRef="Iss_COLNAME_00005">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column7" value="완료 예정일" displayMode="label"
+								localeRef="Iss_COLNAME_00007">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column8" value="상태 (해결 전, 해결 중, 해결 후)" displayMode="label"
+								localeRef="Iss_COLNAME_00008">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column9" value="우선순위 (높음, 중간, 낮음)" displayMode="label"
+								localeRef="Iss_COLNAME_00009">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column10" value="타입 (이슈, 리스크, 테스트)" displayMode="label"
+								localeRef="Iss_COLNAME_00010">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column11" value="상세 내용" displayMode="label"
+								localeRef="Iss_COLNAME_00011">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column12" value="등록일시" displayMode="label"
+								localeRef="Iss_COLNAME_00012">
+							</w2:column>
+							<w2:column width="70" inputType="text" style="" id="column13" value="수정일시" displayMode="label"
+								localeRef="Iss_COLNAME_00013">
+							</w2:column>
+
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" style="" id="pjtId" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="id" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="name" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="userId" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="dueDate" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="status" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="priority" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="type" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="description" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="createdAt" value="" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" style="" id="updatedAt" value="" displayMode="label"></w2:column>
+
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_issList" pageSize="5" pagingType="0" style=""
+					ev:onclick="scwin.pgl_issList_onclick">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_issVo.pageIndex" style=""></w2:span>
+					<w2:span id="span1" label="/" style=""></w2:span>
+					<w2:span id="spn_totalPageCount" label="0" ref="data:dma_issVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group class="pop_contents" id="pop_overlay" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+				meta_snippetName="0_02 팝업페이지시작"
+				style="position: fixed;top: 0;left: 0;width: 100%;height: 100%;background: rgba(0,0,0,0.5);z-index: 1000;display: none;">
+				<xf:group class="pop_contents" id="group1" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+					meta_snippetName="0_02 팝업페이지시작"
+					style="background-color : white; position: relative;  top: 50%;  left: 50%;  transform: translate(-50%, -50%);  background: white;  padding: 20px;  border-radius: 8px;  max-width: 50%;  border : 1px solid grey;">
+					<xf:group class="titbox" id="" style="">
+						<xf:group id="" style="" tagname="h3">
+							<w2:textbox class="" id="" label="이슈리스크관리" localeRef="" style=""></w2:textbox>
+							<w2:textbox class="" id="" label="(" style=""></w2:textbox>
+							<w2:textbox class="" id="textbox1" label="등록" localeRef="COMMON_LABEL_00006" style=""></w2:textbox>
+							<w2:textbox class="" id="" label=")" style=""></w2:textbox>
+						</xf:group>
+						<xf:group class="rt" id="" style="">
+							<xf:trigger class="btn_cm refresh" ev:onclick="scwin.btn_reset_onclick" id="trigger1"
+								localeRef="COMMON_BUTTON_00002" style="" type="button">
+								<xf:label><![CDATA[초기화]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_save_onclick" id="trigger2"
+								localeRef="COMMON_BUTTON_00003" style="" type="button">
+								<xf:label><![CDATA[저장]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_edit_onclick" id="trigger3"
+								localeRef="COMMON_BUTTON_00003" style="" type="button">
+								<xf:label><![CDATA[저장]]></xf:label>
+							</xf:trigger>
+							<xf:trigger class="btn_cm delete" ev:onclick="scwin.btn_delete_onclick" id="trigger4"
+								localeRef="COMMON_BUTTON_00004" style="" type="button">
+								<xf:label><![CDATA[삭제]]></xf:label>
+							</xf:trigger>
+							<xf:trigger anchorWithGroupClass="" class="btn_cm delete icon" id="detail_esc_btn" meta_snippetCategory="08_버튼"
+								meta_snippetKeyComponent="true" meta_snippetName="8_03 아이콘삭제버튼" style="" type="button" ev:onclick="scwin.detail_esc_btn_onclick">
+								<xf:label><![CDATA[Delete]]></xf:label>
+							</xf:trigger>
+						</xf:group>
+					</xf:group>
+					<xf:group adaptive="layout" adaptiveThreshold="600" class="w2tb tbl" id="" style="" tagname="table">
+						<w2:attributes>
+							<w2:summary></w2:summary>
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							<xf:group style="width:150px;" tagname="col"></xf:group>
+							<xf:group style="" tagname="col"></xf:group>
+							<xf:group style="width:150px;" tagname="col"></xf:group>
+							<xf:group style="" tagname="col"></xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="프로젝트 ID" localeRef="Iss_COLNAME_00001" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.pjtId" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="이슈/리스크 고유 ID" localeRef="Iss_COLNAME_00002" ref="" style=""
+									userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.id" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="이슈/리스크명" localeRef="Iss_COLNAME_00003" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.name" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="작성자 사용자 ID" localeRef="Iss_COLNAME_00004" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.userId" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="완료 예정일" localeRef="Iss_COLNAME_00005" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.dueDate" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="상태 (해결 전, 해결 중, 해결 후)" localeRef="Iss_COLNAME_00006" ref="" style=""
+									userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.status" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="우선순위 (높음, 중간, 낮음)" localeRef="Iss_COLNAME_00007" ref="" style=""
+									userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.priority" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="타입 (이슈, 리스크, 테스트)" localeRef="Iss_COLNAME_00008" ref="" style=""
+									userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.type" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="상세 내용" localeRef="Iss_COLNAME_00009" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.description" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="등록일시" localeRef="Iss_COLNAME_00010" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.createdAt" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="수정일시" localeRef="Iss_COLNAME_00011" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.updatedAt" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="resolved_date" localeRef="Iss_COLNAME_00012" ref="" style=""
+									userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.resolvedDate" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr">
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="response_plan" localeRef="Iss_COLNAME_00013" ref="" style=""
+									userData2="">
+								</w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.responsePlan" style="width:100%;"></xf:input>
+							</xf:group>
+							<xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox class="" id="" label="is_deleted" localeRef="Iss_COLNAME_00014" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:input class="" id="" placeholder="" ref="data:dmp_issVoDetail.isDeleted" style="width:100%;"></xf:input>
+							</xf:group>
+						</xf:group>
+						<xf:group style="" tagname="tr"></xf:group>
+					</xf:group>
+				</xf:group>
+			</xf:group>
+			<xf:group class="tblbox" id="grp_issInfo" style=""></xf:group>
+			<xf:group id=""></xf:group>
+			<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+				style="">
+				<w2:textbox class="" id="" label="대기" style="padding : 5px;" tagname="h4"></w2:textbox>
+			</xf:group>
+			<xf:group class="titbox" id="" style="padding">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_waitListCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_waitingList"
+					defaultCellHeight="26" ev:oncellclick="scwin.grd_list_oncellclick" focusMode="row" id="waiting_grd" readOnly="true"
+					scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;" visibleRowNum="10" ev:oncelldblclick="scwin.waiting_grd_oncelldblclick">
+					<w2:caption id="caption15" style="" value="this is a grid caption."></w2:caption>
+					<w2:header id="header2" style="">
+						<w2:row id="row3" style="">
+							<w2:column displayMode="label" id="column2" inputType="text" localeRef="Iss_COLNAME_00002" style=""
+								value="프로젝트 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column3" inputType="text" localeRef="Iss_COLNAME_00003" style=""
+								value="이슈/리스크 고유 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column4" inputType="text" localeRef="Iss_COLNAME_00004" style=""
+								value="이슈/리스크명" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column5" inputType="text" localeRef="Iss_COLNAME_00005" style=""
+								value="작성자 사용자 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column7" inputType="text" localeRef="Iss_COLNAME_00007" style=""
+								value="완료 예정일" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column8" inputType="text" localeRef="Iss_COLNAME_00008" style=""
+								value="상태 (해결 전, 해결 중, 해결 후)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column9" inputType="text" localeRef="Iss_COLNAME_00009" style=""
+								value="우선순위 (높음, 중간, 낮음)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column10" inputType="text" localeRef="Iss_COLNAME_00010" style=""
+								value="타입 (이슈, 리스크, 테스트)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column11" inputType="text" localeRef="Iss_COLNAME_00011" style=""
+								value="상세 내용" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column12" inputType="text" localeRef="Iss_COLNAME_00012" style=""
+								value="등록일시" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column13" inputType="text" localeRef="Iss_COLNAME_00013" style=""
+								value="수정일시" width="70">
+							</w2:column>
+						</w2:row>
+					</w2:header>
+					<w2:gBody id="gBody2" style="">
+						<w2:row id="row4" style="">
+							<w2:column displayMode="label" id="pjtId" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="id" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="name" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="userId" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="dueDate" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="status" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="priority" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="type" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="description" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="createdAt" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="updatedAt" inputType="text" style="" value="" width="70"></w2:column>
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" ev:onclick="scwin.pgl_issList_onclick"
+					id="pageList12" pageSize="5" pagingType="0" style="">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="span14" label="0" ref="data:dma_issVo.pageIndex" style=""></w2:span>
+					<w2:span id="span15" label="/" style=""></w2:span>
+					<w2:span id="span16" label="0" ref="data:dma_issVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span17" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+				style="">
+				<w2:textbox class="" id="" label="해결중" style="padding : 5px;" tagname="h4"></w2:textbox>
+			</xf:group>
+			<xf:group class="titbox" id="" style="padding">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_processingListCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_processingList"
+					defaultCellHeight="26" ev:oncellclick="scwin.grd_list_oncellclick" focusMode="row" id="processing_grd" readOnly="true"
+					scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;" visibleRowNum="10" ev:oncelldblclick="scwin.processing_grd_oncelldblclick">
+					<w2:caption id="caption17" style="" value="this is a grid caption."></w2:caption>
+					<w2:header id="header2" style="">
+						<w2:row id="row3" style="">
+							<w2:column displayMode="label" id="column2" inputType="text" localeRef="Iss_COLNAME_00002" style=""
+								value="프로젝트 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column3" inputType="text" localeRef="Iss_COLNAME_00003" style=""
+								value="이슈/리스크 고유 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column4" inputType="text" localeRef="Iss_COLNAME_00004" style=""
+								value="이슈/리스크명" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column5" inputType="text" localeRef="Iss_COLNAME_00005" style=""
+								value="작성자 사용자 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column7" inputType="text" localeRef="Iss_COLNAME_00007" style=""
+								value="완료 예정일" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column8" inputType="text" localeRef="Iss_COLNAME_00008" style=""
+								value="상태 (해결 전, 해결 중, 해결 후)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column9" inputType="text" localeRef="Iss_COLNAME_00009" style=""
+								value="우선순위 (높음, 중간, 낮음)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column10" inputType="text" localeRef="Iss_COLNAME_00010" style=""
+								value="타입 (이슈, 리스크, 테스트)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column11" inputType="text" localeRef="Iss_COLNAME_00011" style=""
+								value="상세 내용" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column12" inputType="text" localeRef="Iss_COLNAME_00012" style=""
+								value="등록일시" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column13" inputType="text" localeRef="Iss_COLNAME_00013" style=""
+								value="수정일시" width="70">
+							</w2:column>
+						</w2:row>
+					</w2:header>
+					<w2:gBody id="gBody2" style="">
+						<w2:row id="row4" style="">
+							<w2:column displayMode="label" id="pjtId" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="id" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="name" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="userId" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="dueDate" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="status" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="priority" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="type" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="description" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="createdAt" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="updatedAt" inputType="text" style="" value="" width="70"></w2:column>
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="titbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_03 서브타이틀(h4)"
+				style="">
+				<w2:textbox class="" id="" label="완료" style="padding : 5px;" tagname="h4"></w2:textbox>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_completeListCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_completedList"
+					defaultCellHeight="26" ev:oncellclick="scwin.grd_list_oncellclick" focusMode="row" id="complete_grd" readOnly="true"
+					scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;" visibleRowNum="10" ev:oncelldblclick="scwin.complete_grd_oncelldblclick">
+					<w2:caption id="caption18" style="" value="this is a grid caption."></w2:caption>
+					<w2:header id="header2" style="">
+						<w2:row id="row3" style="">
+							<w2:column displayMode="label" id="column2" inputType="text" localeRef="Iss_COLNAME_00002" style=""
+								value="프로젝트 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column3" inputType="text" localeRef="Iss_COLNAME_00003" style=""
+								value="이슈/리스크 고유 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column4" inputType="text" localeRef="Iss_COLNAME_00004" style=""
+								value="이슈/리스크명" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column5" inputType="text" localeRef="Iss_COLNAME_00005" style=""
+								value="작성자 사용자 ID" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column7" inputType="text" localeRef="Iss_COLNAME_00007" style=""
+								value="완료 예정일" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column8" inputType="text" localeRef="Iss_COLNAME_00008" style=""
+								value="상태 (해결 전, 해결 중, 해결 후)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column9" inputType="text" localeRef="Iss_COLNAME_00009" style=""
+								value="우선순위 (높음, 중간, 낮음)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column10" inputType="text" localeRef="Iss_COLNAME_00010" style=""
+								value="타입 (이슈, 리스크, 테스트)" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column11" inputType="text" localeRef="Iss_COLNAME_00011" style=""
+								value="상세 내용" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column12" inputType="text" localeRef="Iss_COLNAME_00012" style=""
+								value="등록일시" width="70">
+							</w2:column>
+							<w2:column displayMode="label" id="column13" inputType="text" localeRef="Iss_COLNAME_00013" style=""
+								value="수정일시" width="70">
+							</w2:column>
+						</w2:row>
+					</w2:header>
+					<w2:gBody id="gBody2" style="">
+						<w2:row id="row4" style="">
+							<w2:column displayMode="label" id="pjtId" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="id" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="name" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="userId" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="dueDate" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="status" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="priority" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="type" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="description" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="createdAt" inputType="text" style="" value="" width="70"></w2:column>
+							<w2:column displayMode="label" id="updatedAt" inputType="text" style="" value="" width="70"></w2:column>
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" ev:onclick="scwin.pgl_issList_onclick"
+					id="pageList13" pageSize="5" pagingType="0" style="">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="span21" label="0" ref="data:dma_issVo.pageIndex" style=""></w2:span>
+					<w2:span id="span22" label="/" style=""></w2:span>
+					<w2:span id="span23" label="0" ref="data:dma_issVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span24" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/iss/IssList.xml
+++ b/src/main/webapp/ui/iss/IssList.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_issVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지_번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지_건수" defaultValue="10"></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_issVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="id" name="이슈/리스크 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="이슈/리스크명"></w2:column>
+                        <w2:column dataType="text" id="userId" name="작성자 사용자 ID"></w2:column>
+                        <w2:column dataType="text" id="dueDate" name="완료 예정일"></w2:column>
+                        <w2:column dataType="text" id="status" name="상태 (해결 전, 해결 중, 해결 후)"></w2:column>
+                        <w2:column dataType="text" id="priority" name="우선순위 (높음, 중간, 낮음)"></w2:column>
+                        <w2:column dataType="text" id="type" name="타입 (이슈, 리스크, 테스트)"></w2:column>
+                        <w2:column dataType="text" id="description" name="상세 내용"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="resolvedDate" name="resolved_date"></w2:column>
+                        <w2:column dataType="text" id="responsePlan" name="response_plan"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="is_deleted"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_issVoDetail" style="">
+					<w2:keyInfo>
+						
+					</w2:keyInfo>
+				</w2:dataMap>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectIssVoList" ref='data:json,{"id":"dmp_issVo","key":"issVo"}'
+				target='data:json,{"id":"dlt_issVoList","key":"elData.issVoList"}' action="/InsWebApp/ISS001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="이슈리스크관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_issList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 이슈리스크관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_issVo.set("pageIndex","1");
+		pgl_issList.setSelectedIndex(1);
+
+		// 서버통신 - 이슈리스크관리 조회
+		$c.sbm.execute($p, sbm_selectIssVoList);
+	};
+	
+	scwin.sbm_issList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+		// 이슈리스크관리 dataMap 초기화
+		dmp_issVoDetail.setEmptyValue();
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_issVoList.setJSON(elData.issVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_issVo.get("pageSize"));
+        pgl_issList.setCount(totalPageCount);
+        
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_issVo.get("pageIndex"));
+        pgl_issList.setSelectedIndex(dmp_issVo.get("pageIndex"));
+	};		
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_issList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_issVo.set( "pageIndex" , idx ); 
+		// 서버통신 - 사원목록 조회
+		$c.sbm.execute($p, sbm_selectIssVoList);
+	};
+
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="이슈리스크관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+								
+							</xf:group>
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button" ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+    				<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+    				<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+    			</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_issVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" inputType="text" style="" id="column1" value="프로젝트 ID" displayMode="label" localeRef="Iss_COLNAME_00001"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column2" value="이슈/리스크 고유 ID" displayMode="label" localeRef="Iss_COLNAME_00002"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column3" value="이슈/리스크명" displayMode="label" localeRef="Iss_COLNAME_00003"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column4" value="작성자 사용자 ID" displayMode="label" localeRef="Iss_COLNAME_00004"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column5" value="완료 예정일" displayMode="label" localeRef="Iss_COLNAME_00005"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column6" value="상태 (해결 전, 해결 중, 해결 후)" displayMode="label" localeRef="Iss_COLNAME_00006"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column7" value="우선순위 (높음, 중간, 낮음)" displayMode="label" localeRef="Iss_COLNAME_00007"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column8" value="타입 (이슈, 리스크, 테스트)" displayMode="label" localeRef="Iss_COLNAME_00008"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column9" value="상세 내용" displayMode="label" localeRef="Iss_COLNAME_00009"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column10" value="등록일시" displayMode="label" localeRef="Iss_COLNAME_00010"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column11" value="수정일시" displayMode="label" localeRef="Iss_COLNAME_00011"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column12" value="resolved_date" displayMode="label" localeRef="Iss_COLNAME_00012"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column13" value="response_plan" displayMode="label" localeRef="Iss_COLNAME_00013"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column14" value="is_deleted" displayMode="label" localeRef="Iss_COLNAME_00014"></w2:column>
+                           
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" style="" id="pjtId" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="id" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="name" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="userId" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="dueDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="status" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="priority" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="type" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="description" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="createdAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="updatedAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="resolvedDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="responsePlan" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="isDeleted" value="" displayMode="label"></w2:column>
+                           
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_issList" pageSize="5" pagingType="0"
+					style="" ev:onclick="scwin.pgl_issList_onclick">
+				</w2:pageList>	
+				<xf:group class="pgl_count" id="" style="display: none;">
+    				<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_issVo.pageIndex" style=""></w2:span>
+    				<w2:span id="span1" label="/" style=""></w2:span>
+    				<w2:span id="spn_totalPageCount" label="0" ref="data:dma_issVo.totalPageCount" style=""></w2:span>
+    				<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+    			</xf:group>		
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/out/Out.xml
+++ b/src/main/webapp/ui/out/Out.xml
@@ -1,0 +1,605 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_outVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지사이즈" defaultValue="10"></w2:key>
+						<w2:key dataType="text" id="totalPageCount" name="페이지건수" ></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_outVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="산출물 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="산출물명"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="approvalStatus" name="승인 상태 (대기/승인/반려)"></w2:column>
+                        <w2:column dataType="text" id="approvalDate" name="승인일시"></w2:column>
+                        <w2:column dataType="text" id="approvalComment" name="승인/반려 의견"></w2:column>
+                        <w2:column dataType="text" id="outputType" name="산출물 유형"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_outVoDetail" style="">
+					<w2:keyInfo>
+						<w2:key dataType="text" id="id" name="산출물 고유 ID"></w2:key>
+                        <w2:key dataType="text" id="pjtId" name="프로젝트 ID"></w2:key>
+                        <w2:key dataType="text" id="name" name="산출물명"></w2:key>
+                        <w2:key dataType="text" id="createdAt" name="등록일시"></w2:key>
+                        <w2:key dataType="text" id="updatedAt" name="수정일시"></w2:key>
+                        <w2:key dataType="text" id="approvalStatus" name="승인 상태 (대기/승인/반려)"></w2:key>
+                        <w2:key dataType="text" id="approvalDate" name="승인일시"></w2:key>
+                        <w2:key dataType="text" id="approvalComment" name="승인/반려 의견"></w2:key>
+                        <w2:key dataType="text" id="outputType" name="산출물 유형"></w2:key>
+                        <w2:key dataType="text" id="isDeleted" name="삭제 여부"></w2:key>
+                       
+					</w2:keyInfo>
+				</w2:dataMap>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectOutVoList" ref='data:json,{"id":"dmp_outVo","key":"outVo"}'
+				target='data:json,{"id":"dlt_outVoList","key":"elData.outVoList"}' action="/InsWebApp/OUT001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="산출물관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_outList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_deleteOutVo" ref='data:json,{"id":"dmp_outVoDetail","key":"outVo"}' target="" action="/InsWebApp/OUT001Del.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_deleteOutVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_updateOutVo" ref='data:json,["dmp_outVoDetail",{"id":"dmp_outVoDetail","key":"outVo"}]' target="" action="/InsWebApp/OUT001Upd.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_updateOutVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_insertOutVo" ref='data:json,["dmp_outVoDetail",{"id":"dmp_outVoDetail","key":"outVo"}]' target="" action="/InsWebApp/OUT001Ins.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_insertOutVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_selectOutVo" ref="" target="" action="/InsWebApp/OUT001UpdView.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="산출물관리를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_selectOutVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {
+		// 산출물관리 readOnly false
+		
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼 
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//sel_pageSize.setValue("10");
+		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 산출물관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_outVo.set("pageIndex","1");
+		pgl_outList.setSelectedIndex(1);
+
+		// 서버통신 - 산출물관리 조회
+		$c.sbm.execute($p, sbm_selectOutVoList);
+	};
+	
+	scwin.sbm_outList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+		// 산출물관리 dataMap 초기화
+		dmp_outVoDetail.setEmptyValue();
+		
+		// 산출물관리 readOnly false
+		grp_outInfo.setReadOnly(false);
+		
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거		
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_outVoList.setJSON(elData.outVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_outVo.get("pageSize"));
+        pgl_outList.setCount(totalPageCount);
+        
+        spn_registerFlag.setValue("등록");
+
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_outVo.get("pageIndex"));
+        pgl_outList.setSelectedIndex(dmp_outVo.get("pageIndex"));
+	};	
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_outList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_outVo.set("pageIndex", idx);
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//dmp_outVo.set("pageSize", sel_pageSize.getValue());
+		 
+		// 서버통신 - 산출물관리 조회
+		$c.sbm.execute($p, sbm_selectOutVoList);
+	};
+
+	// 산출물관리 clear
+	scwin.btn_reset_onclick = function(e) {
+	
+		// 산출물관리 dataMap 초기화
+		dmp_outVoDetail.setEmptyValue();
+		// 산출물관리 readOnly false
+		grp_outInfo.setReadOnly(false);
+
+		btn_save.show("");   // 저장 버튼 생성
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		spn_registerFlag.setValue("등록");
+	};
+
+	/**
+	 * 그리드 셀 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.grd_list_oncellclick = function(row,col,colId) {
+
+		dmp_outVoDetail.setJSON(dlt_outVoList.getRowJSON(row));
+
+		btn_save.hide(); 		// 저장 버튼 제거
+		btn_edit.show("");      // 수정 버튼 생성
+		btn_delete.show("");    // 삭제 버튼 생성
+		
+		spn_registerFlag.setValue("수정");
+	};
+
+	/**
+	 * 저장 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */	
+	scwin.btn_save_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_outInfo, valInfo) === true) {
+			var promise = $c.win.confirm("저장하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_insertOutVo);
+				}
+			})
+		} 	
+	};
+
+	/**
+	 * 사원정보 등록 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_insertOutVo_submitdone = function(e) {
+		
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 등록되었습니다. msg 출력
+			$c.win.alert("등록되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 수정 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_edit_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_outInfo, valInfo) === true) {
+			var promise = $c.win.confirm("수정하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_updateOutVo);
+				}
+			})
+		} 
+	};
+
+	/**
+	 * 사원정보 수정 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_updateOutVo_submitdone = function(e) {
+
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 수정되었습니다. msg 출력
+			$c.win.alert("수정되었습니다.");
+		}
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 삭제 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_delete_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_outInfo, valInfo) === true) {
+			var promise = $c.win.confirm("삭제하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_deleteOutVo);
+				}
+			})
+		}	
+	};
+
+	/**
+	 * 삭제 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_deleteOutVo_submitdone = function(e) {
+	
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 삭제되었습니다. msg 출력
+			$c.win.alert("삭제되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="산출물관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+								
+							</xf:group>
+							<!-- 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제-->
+							<!--xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox id="" label="페이지 크기" localeRef="COMMON_LABEL_00001" ref="" style="" userData2=""></w2:textbox>
+							</xf:group>
+							<xf:group class="w2tb_td" style="" tagname="td">
+    							<xf:select1 allOption="" appearance="minimal" chooseOption="" direction="auto" disabled="false"
+    								disabledClass="w2selectbox_disabled" id="sel_pageSize" ref="data:dmp_outVo.pageSize" renderType="native"
+    								style="width: 80px;" submenuSize="auto" useItemLocale="false">
+    								<xf:choices>
+    									<xf:item>
+    										<xf:label><![CDATA[5]]></xf:label>
+    										<xf:value><![CDATA[5]]></xf:value>
+    									</xf:item>
+    									<xf:item>
+    										<xf:label><![CDATA[10]]></xf:label>
+    										<xf:value><![CDATA[10]]></xf:value>
+    									</xf:item>
+    									<xf:item>
+    										<xf:label><![CDATA[20]]></xf:label>
+    										<xf:value><![CDATA[20]]></xf:value>
+    									</xf:item>
+    									<xf:item>
+    										<xf:label><![CDATA[30]]></xf:label>
+    										<xf:value><![CDATA[30]]></xf:value>
+    									</xf:item>
+    									<xf:item>
+    										<xf:label><![CDATA[50]]></xf:label>
+    										<xf:value><![CDATA[50]]></xf:value>
+    									</xf:item>
+    									<xf:item>
+    										<xf:label><![CDATA[100]]></xf:label>
+    										<xf:value><![CDATA[100]]></xf:value>
+    									</xf:item>
+    								</xf:choices>
+    							</xf:select1>
+    						</xf:group-->
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button" ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+    				<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+    				<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+    			</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_outVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" inputType="text" style="" id="column1" value="산출물 고유 ID" displayMode="label" localeRef="Out_COLNAME_00001"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column2" value="프로젝트 ID" displayMode="label" localeRef="Out_COLNAME_00002"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column3" value="산출물명" displayMode="label" localeRef="Out_COLNAME_00003"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column4" value="등록일시" displayMode="label" localeRef="Out_COLNAME_00004"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column5" value="수정일시" displayMode="label" localeRef="Out_COLNAME_00005"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column6" value="승인 상태 (대기/승인/반려)" displayMode="label" localeRef="Out_COLNAME_00006"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column7" value="승인일시" displayMode="label" localeRef="Out_COLNAME_00007"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column8" value="승인/반려 의견" displayMode="label" localeRef="Out_COLNAME_00008"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column9" value="산출물 유형" displayMode="label" localeRef="Out_COLNAME_00009"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column10" value="삭제 여부" displayMode="label" localeRef="Out_COLNAME_00010"></w2:column>
+                           
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" style="" id="id" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="pjtId" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="name" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="createdAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="updatedAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="approvalStatus" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="approvalDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="approvalComment" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="outputType" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="isDeleted" value="" displayMode="label"></w2:column>
+                           
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_outList" pageSize="5" pagingType="0"
+					style="" ev:onclick="scwin.pgl_outList_onclick">
+				</w2:pageList>	
+				<xf:group class="pgl_count" id="" style="display: none;">
+    				<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_outVo.pageIndex" style=""></w2:span>
+    				<w2:span id="span1" label="/" style=""></w2:span>
+    				<w2:span id="spn_totalPageCount" label="0" ref="data:dma_outVo.totalPageCount" style=""></w2:span>
+    				<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+    			</xf:group>		
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+                <xf:group id="" tagname="h3" style="">
+    				<w2:textbox class="" id="" label="산출물관리" localeRef="" style=""></w2:textbox>
+    				<w2:textbox class="" id="" label="(" style=""></w2:textbox>
+    				<w2:textbox class="" id="spn_registerFlag" label="등록" localeRef="COMMON_LABEL_00006" style=""></w2:textbox>
+    				<w2:textbox class="" id="" label=")" style=""></w2:textbox>
+    			</xf:group>
+
+				<xf:group class="rt" id="" style="">
+					<xf:trigger class="btn_cm refresh" id="btn_reset" style="" type="button" localeRef="COMMON_BUTTON_00002"
+	    					ev:onclick="scwin.btn_reset_onclick">
+	    					<xf:label><![CDATA[초기화]]></xf:label>
+					</xf:trigger>
+					<xf:trigger class="btn_cm save" id="btn_save" style="" type="button" localeRef="COMMON_BUTTON_00003" ev:onclick="scwin.btn_save_onclick">
+	    					<xf:label><![CDATA[저장]]></xf:label>
+					</xf:trigger>
+					<xf:trigger class="btn_cm save" id="btn_edit" style="" type="button" localeRef="COMMON_BUTTON_00003" ev:onclick="scwin.btn_edit_onclick">
+						<xf:label><![CDATA[저장]]></xf:label>
+					</xf:trigger>
+					<xf:trigger class="btn_cm delete" ev:onclick="scwin.btn_delete_onclick" id="btn_delete" localeRef="COMMON_BUTTON_00004"
+						style="" type="button">
+						<xf:label><![CDATA[삭제]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="tblbox" id="grp_outInfo" style="">
+				<xf:group adaptive="layout" adaptiveThreshold="600" class="w2tb tbl" id="" style="" tagname="table">
+					<w2:attributes>
+						<w2:summary />
+					</w2:attributes>
+					<xf:group tagname="colgroup">
+						<xf:group style="width:150px;" tagname="col" />
+						<xf:group style="" tagname="col" />
+						<xf:group style="width:150px;" tagname="col" />
+						<xf:group style="" tagname="col" />
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="산출물 고유 ID" ref="" style="" userData2="" localeRef="Out_COLNAME_00001"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.id"/>
+                        </xf:group>
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="프로젝트 ID" ref="" style="" userData2="" localeRef="Out_COLNAME_00002"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.pjtId"/>
+                        </xf:group>
+                    </xf:group>
+                    <xf:group style="" tagname="tr">
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="산출물명" ref="" style="" userData2="" localeRef="Out_COLNAME_00003"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.name"/>
+                        </xf:group>
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="등록일시" ref="" style="" userData2="" localeRef="Out_COLNAME_00004"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.createdAt"/>
+                        </xf:group>
+                    </xf:group>
+                    <xf:group style="" tagname="tr">
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="수정일시" ref="" style="" userData2="" localeRef="Out_COLNAME_00005"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.updatedAt"/>
+                        </xf:group>
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="승인 상태 (대기/승인/반려)" ref="" style="" userData2="" localeRef="Out_COLNAME_00006"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.approvalStatus"/>
+                        </xf:group>
+                    </xf:group>
+                    <xf:group style="" tagname="tr">
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="승인일시" ref="" style="" userData2="" localeRef="Out_COLNAME_00007"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.approvalDate"/>
+                        </xf:group>
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="승인/반려 의견" ref="" style="" userData2="" localeRef="Out_COLNAME_00008"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.approvalComment"/>
+                        </xf:group>
+                    </xf:group>
+                    <xf:group style="" tagname="tr">
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="산출물 유형" ref="" style="" userData2="" localeRef="Out_COLNAME_00009"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.outputType"/>
+                        </xf:group>
+                        <xf:group class="w2tb_th" style="" tagname="th">
+                            <w2:textbox class="" id="" label="삭제 여부" ref="" style="" userData2="" localeRef="Out_COLNAME_00010"/>
+                        </xf:group>
+                        <xf:group class="w2tb_td" style="" tagname="td">
+                            <xf:input class="" id="" placeholder="" style="width:100%;" ref="data:dmp_outVoDetail.isDeleted"/>
+                        </xf:group>
+                    </xf:group>
+                    <xf:group style="" tagname="tr">
+                       
+					</xf:group>
+				</xf:group>
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/out/OutList.xml
+++ b/src/main/webapp/ui/out/OutList.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_outVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지_번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지_건수" defaultValue="10"></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_outVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="산출물 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="pjtId" name="프로젝트 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="산출물명"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                        <w2:column dataType="text" id="approvalStatus" name="승인 상태 (대기/승인/반려)"></w2:column>
+                        <w2:column dataType="text" id="approvalDate" name="승인일시"></w2:column>
+                        <w2:column dataType="text" id="approvalComment" name="승인/반려 의견"></w2:column>
+                        <w2:column dataType="text" id="outputType" name="산출물 유형"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_outVoDetail" style="">
+					<w2:keyInfo>
+						
+					</w2:keyInfo>
+				</w2:dataMap>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectOutVoList" ref='data:json,{"id":"dmp_outVo","key":"outVo"}'
+				target='data:json,{"id":"dlt_outVoList","key":"elData.outVoList"}' action="/InsWebApp/OUT001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="산출물관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_outList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 산출물관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_outVo.set("pageIndex","1");
+		pgl_outList.setSelectedIndex(1);
+
+		// 서버통신 - 산출물관리 조회
+		$c.sbm.execute($p, sbm_selectOutVoList);
+	};
+	
+	scwin.sbm_outList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+		// 산출물관리 dataMap 초기화
+		dmp_outVoDetail.setEmptyValue();
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_outVoList.setJSON(elData.outVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_outVo.get("pageSize"));
+        pgl_outList.setCount(totalPageCount);
+        
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_outVo.get("pageIndex"));
+        pgl_outList.setSelectedIndex(dmp_outVo.get("pageIndex"));
+	};		
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_outList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_outVo.set( "pageIndex" , idx ); 
+		// 서버통신 - 사원목록 조회
+		$c.sbm.execute($p, sbm_selectOutVoList);
+	};
+
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="산출물관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+								
+							</xf:group>
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button" ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+    				<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+    				<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+    			</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_outVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" inputType="text" style="" id="column1" value="산출물 고유 ID" displayMode="label" localeRef="Out_COLNAME_00001"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column2" value="프로젝트 ID" displayMode="label" localeRef="Out_COLNAME_00002"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column3" value="산출물명" displayMode="label" localeRef="Out_COLNAME_00003"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column4" value="등록일시" displayMode="label" localeRef="Out_COLNAME_00004"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column5" value="수정일시" displayMode="label" localeRef="Out_COLNAME_00005"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column6" value="승인 상태 (대기/승인/반려)" displayMode="label" localeRef="Out_COLNAME_00006"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column7" value="승인일시" displayMode="label" localeRef="Out_COLNAME_00007"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column8" value="승인/반려 의견" displayMode="label" localeRef="Out_COLNAME_00008"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column9" value="산출물 유형" displayMode="label" localeRef="Out_COLNAME_00009"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column10" value="삭제 여부" displayMode="label" localeRef="Out_COLNAME_00010"></w2:column>
+                           
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" style="" id="id" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="pjtId" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="name" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="createdAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="updatedAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="approvalStatus" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="approvalDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="approvalComment" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="outputType" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="isDeleted" value="" displayMode="label"></w2:column>
+                           
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_outList" pageSize="5" pagingType="0"
+					style="" ev:onclick="scwin.pgl_outList_onclick">
+				</w2:pageList>	
+				<xf:group class="pgl_count" id="" style="display: none;">
+    				<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_outVo.pageIndex" style=""></w2:span>
+    				<w2:span id="span1" label="/" style=""></w2:span>
+    				<w2:span id="spn_totalPageCount" label="0" ref="data:dma_outVo.totalPageCount" style=""></w2:span>
+    				<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+    			</xf:group>		
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/test/Test.xml
+++ b/src/main/webapp/ui/test/Test.xml
@@ -1,0 +1,711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_testVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지사이즈" defaultValue="10"></w2:key>
+						<w2:key dataType="text" id="totalPageCount" name="페이지건수" ></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_testVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="테스트 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="taskId" name="연결된 업무 ID"></w2:column>
+                        <w2:column dataType="text" id="taskName" name="연결된 업무명"></w2:column>
+                        <w2:column dataType="text" id="name" name="테스트 케이스명"></w2:column>
+                        <w2:column dataType="text" id="category" name="테스트 카테고리"></w2:column>
+                        <w2:column dataType="text" id="scenario" name="테스트 실행 시나리오"></w2:column>
+                        <w2:column dataType="text" id="inputData" name="테스트 입력 데이터"></w2:column>
+                        <w2:column dataType="text" id="expectedResult" name="예상 결과"></w2:column>
+                        <w2:column dataType="text" id="actualResult" name="실제 결과"></w2:column>
+                        <w2:column dataType="text" id="testResult" name="테스트 결과"></w2:column>
+                        <w2:column dataType="text" id="assignee" name="테스트 담당자"></w2:column>
+                        <w2:column dataType="text" id="userName" name="담당자"></w2:column>
+                        <w2:column dataType="text" id="executionDate" name="테스트 실행일"></w2:column>
+                        <w2:column dataType="text" id="duration" name="테스트 소요시간(분)"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_testVoDetail" style="">
+					<w2:keyInfo>
+						<w2:key dataType="text" id="id" name="테스트 고유 ID"></w2:key>
+                        <w2:key dataType="text" id="taskId" name="연결된 업무 ID"></w2:key>
+                        <w2:key dataType="text" id="name" name="테스트 케이스명"></w2:key>
+                        <w2:key dataType="text" id="category" name="테스트 카테고리"></w2:key>
+                        <w2:key dataType="text" id="scenario" name="테스트 실행 시나리오"></w2:key>
+                        <w2:key dataType="text" id="inputData" name="테스트 입력 데이터"></w2:key>
+                        <w2:key dataType="text" id="expectedResult" name="예상 결과"></w2:key>
+                        <w2:key dataType="text" id="actualResult" name="실제 결과"></w2:key>
+                        <w2:key dataType="text" id="testResult" name="테스트 결과"></w2:key>
+                        <w2:key dataType="text" id="assignee" name="테스트 담당자"></w2:key>
+                        <w2:key dataType="text" id="executionDate" name="테스트 실행일"></w2:key>
+                        <w2:key dataType="text" id="duration" name="테스트 소요시간(분)"></w2:key>
+                        <w2:key dataType="text" id="isDeleted" name="삭제 여부"></w2:key>
+                        <w2:key dataType="text" id="createdAt" name="등록일시"></w2:key>
+                        <w2:key dataType="text" id="updatedAt" name="수정일시"></w2:key>
+                       
+					</w2:keyInfo>
+				</w2:dataMap>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectTestVoList" ref='data:json,{"id":"dmp_testVo","key":"testVo"}'
+				target='data:json,{"id":"dlt_testVoList","key":"elData.testVoList"}' action="/InsWebApp/TEST001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="테스트관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_testList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_deleteTestVo" ref='data:json,{"id":"dmp_testVoDetail","key":"testVo"}' target="" action="/InsWebApp/TEST001Del.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_deleteTestVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_updateTestVo" ref='data:json,["dmp_testVoDetail",{"id":"dmp_testVoDetail","key":"testVo"}]' target="" action="/InsWebApp/TEST001Upd.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_updateTestVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_insertTestVo" ref='data:json,["dmp_testVoDetail",{"id":"dmp_testVoDetail","key":"testVo"}]' target="" action="/InsWebApp/TEST001Ins.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous" processMsg=""
+				ev:submit="" ev:submitdone="scwin.sbm_insertTestVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+			<xf:submission id="sbm_selectTestVo" ref="" target="" action="/InsWebApp/TEST001UpdView.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="테스트관리를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_selectTestVo_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {
+		// 테스트관리 readOnly false
+		
+    
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼 
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//sel_pageSize.setValue("10");
+		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 테스트관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_testVo.set("pageIndex","1");
+		pgl_testList.setSelectedIndex(1);
+
+		// 서버통신 - 테스트관리 조회
+		$c.sbm.execute($p, sbm_selectTestVoList);
+	};
+	
+	scwin.sbm_testList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+		// 테스트관리 dataMap 초기화
+		dmp_testVoDetail.setEmptyValue();
+		
+		// 테스트관리 readOnly false
+		grp_testInfo.setReadOnly(false);
+		
+		// 버튼 숨김
+		btn_save.show("");   // 저장 버튼
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거		
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_testVoList.setJSON(elData.testVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_testVo.get("pageSize"));
+        pgl_testList.setCount(totalPageCount);
+        
+        spn_registerFlag.setValue("등록");
+
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_testVo.get("pageIndex"));
+        pgl_testList.setSelectedIndex(dmp_testVo.get("pageIndex"));
+	};	
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_testList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_testVo.set("pageIndex", idx);
+		
+		/////////////////////////////////////////////
+		// 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제
+		/////////////////////////////////////////////
+		//dmp_testVo.set("pageSize", sel_pageSize.getValue());
+		 
+		// 서버통신 - 테스트관리 조회
+		$c.sbm.execute($p, sbm_selectTestVoList);
+	};
+
+	// 테스트관리 clear
+	scwin.btn_reset_onclick = function(e) {
+	
+		// 테스트관리 dataMap 초기화
+		dmp_testVoDetail.setEmptyValue();
+		// 테스트관리 readOnly false
+		grp_testInfo.setReadOnly(false);
+
+		btn_save.show("");   // 저장 버튼 생성
+		btn_edit.hide();     // 수정 버튼 제거
+		btn_delete.hide();   // 삭제 버튼 제거
+		
+		spn_registerFlag.setValue("등록");
+	};
+
+	/**
+	 * 그리드 셀 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.grd_list_oncellclick = function(row,col,colId) {
+
+		dmp_testVoDetail.setJSON(dlt_testVoList.getRowJSON(row));
+
+		btn_save.hide(); 		// 저장 버튼 제거
+		btn_edit.show("");      // 수정 버튼 생성
+		btn_delete.show("");    // 삭제 버튼 생성
+		
+		spn_registerFlag.setValue("수정");
+	};
+
+	/**
+	 * 저장 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */	
+	scwin.btn_save_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_testInfo, valInfo) === true) {
+			var promise = $c.win.confirm("저장하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_insertTestVo);
+				}
+			})
+		} 	
+	};
+
+	/**
+	 * 사원정보 등록 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_insertTestVo_submitdone = function(e) {
+		
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 등록되었습니다. msg 출력
+			$c.win.alert("등록되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 수정 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_edit_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_testInfo, valInfo) === true) {
+			var promise = $c.win.confirm("수정하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_updateTestVo);
+				}
+			})
+		} 
+	};
+
+	/**
+	 * 사원정보 수정 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_updateTestVo_submitdone = function(e) {
+
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 수정되었습니다. msg 출력
+			$c.win.alert("수정되었습니다.");
+		}
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+	/**
+	 * 삭제 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */		
+	scwin.btn_delete_onclick = function(e) {
+		
+		// 유효성 체크
+		var valInfo = [
+			{ id: "id", mandatory: true }
+           
+		];
+		
+		if ($c.data.validateGroup(grp_testInfo, valInfo) === true) {
+			var promise = $c.win.confirm("삭제하시겠습니까?");
+			promise.then(function(result) {  
+				if (result){
+					$c.sbm.execute(sbm_deleteTestVo);
+				}
+			})
+		}	
+	};
+
+	/**
+	 * 삭제 콜백
+	 * @date 
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.sbm_deleteTestVo_submitdone = function(e) {
+	
+		// error 수신시
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}else{
+			// 삭제되었습니다. msg 출력
+			$c.win.alert("삭제되었습니다.");
+		}
+		
+		// 재조회
+		scwin.btn_search_onclick();
+	};
+
+scwin.grd_list_oncelldblclick = function (rowIndex, columnIndex, columnId) {
+    popup_grp.show();
+};
+
+scwin.esc_btn_onclick = function (e) {
+    popup_grp.hide();
+};
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="테스트관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+
+							</xf:group>
+							<!-- 페이지 크기 설정 영역 / 웹관리자 화면 page 생성 시 주석 해제-->
+							<!--xf:group class="w2tb_th" style="" tagname="th">
+								<w2:textbox id="" label="페이지 크기" localeRef="COMMON_LABEL_00001" ref="" style="" userData2=""></w2:textbox>
+								</xf:group>
+								<xf:group class="w2tb_td" style="" tagname="td">
+								<xf:select1 allOption="" appearance="minimal" chooseOption="" direction="auto" disabled="false"
+								disabledClass="w2selectbox_disabled" id="sel_pageSize" ref="data:dmp_testVo.pageSize" renderType="native"
+								style="width: 80px;" submenuSize="auto" useItemLocale="false">
+								<xf:choices>
+								<xf:item>
+								<xf:label><![CDATA[5]]></xf:label>
+								<xf:value><![CDATA[5]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[10]]></xf:label>
+								<xf:value><![CDATA[10]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[20]]></xf:label>
+								<xf:value><![CDATA[20]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[30]]></xf:label>
+								<xf:value><![CDATA[30]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[50]]></xf:label>
+								<xf:value><![CDATA[50]]></xf:value>
+								</xf:item>
+								<xf:item>
+								<xf:label><![CDATA[100]]></xf:label>
+								<xf:value><![CDATA[100]]></xf:value>
+								</xf:item>
+								</xf:choices>
+								</xf:select1>
+								</xf:group-->
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button"
+						ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+					<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+					<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_testVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="15" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true" ev:oncelldblclick="scwin.grd_list_oncelldblclick">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="100" inputType="text" id="column1" value="테스트 고유 ID" displayMode="label"
+								localeRef="Test_COLNAME_00001">
+							</w2:column>
+							<w2:column width="120" inputType="text" id="column2" value="연결된 업무명" displayMode="label"
+								localeRef="Test_COLNAME_00002">
+							</w2:column>
+							<w2:column width="200" inputType="text" id="column3" value="테스트 케이스명" displayMode="label"
+								localeRef="Test_COLNAME_00003">
+							</w2:column>
+							<w2:column width="120" inputType="text" id="column4" value="테스트 카테고리" displayMode="label"
+								localeRef="Test_COLNAME_00004">
+							</w2:column>
+							<w2:column width="100" inputType="text" id="column9" value="테스트 결과" displayMode="label"
+								localeRef="Test_COLNAME_00009">
+							</w2:column>
+							<w2:column width="120" inputType="text" id="column10" value="테스트 담당자" displayMode="label"
+								localeRef="Test_COLNAME_00010">
+							</w2:column>
+							<w2:column width="70" inputType="text" id="column43" value="담당자" displayMode="label"
+								localeRef="Test_COLNAME_00011">
+							</w2:column>
+							<w2:column width="120" inputType="text" id="column11" value="테스트 실행일" displayMode="label"
+								localeRef="Test_COLNAME_00012">
+							</w2:column>
+							<w2:column width="100" inputType="text" id="column12" value="소요시간(분)" displayMode="label"
+								localeRef="Test_COLNAME_00013">
+							</w2:column>
+							<w2:column width="140" inputType="text" id="column14" value="등록일시" displayMode="label"
+								localeRef="Test_COLNAME_00014">
+							</w2:column>
+							<w2:column width="140" inputType="text" id="column15" value="수정일시" displayMode="label"
+								localeRef="Test_COLNAME_00015">
+							</w2:column>
+						</w2:row>
+					</w2:header>
+
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="100" inputType="text" id="id" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="taskName" displayMode="label"></w2:column>
+							<w2:column width="200" inputType="text" id="name" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="category" displayMode="label"></w2:column>
+							<w2:column width="100" inputType="output" id="testResult" displayMode="label">
+								<!-- 테스트 결과 색상 표시 -->
+								<w2:span id="spanPass" label="PASS"
+									style="background: #e6ffe6; color: #009900; padding: 2px 6px; border: 1px solid #99ff99; font-size: 10px; font-weight: bold; margin-right: 5px; border-radius: 3px;"
+									visibleExpression="testResult == 'PASS' || testResult == '통과'">
+								</w2:span>
+
+								<w2:span id="spanFail" label="FAIL"
+									style="background: #ffe6e6; color: #cc0000; padding: 2px 6px; border: 1px solid #ff9999; font-size: 10px; font-weight: bold; margin-right: 5px; border-radius: 3px;"
+									visibleExpression="testResult == 'FAIL' || testResult == '실패'">
+								</w2:span>
+
+								<w2:span id="spanPending" label="PENDING"
+									style="background: #fff2e6; color: #cc6600; padding: 2px 6px; border: 1px solid #ffcc99; font-size: 10px; margin-right: 5px; border-radius: 3px;"
+									visibleExpression="testResult == 'PENDING' || testResult == '대기'">
+								</w2:span>
+							</w2:column>
+							<w2:column width="120" inputType="text" id="assignee" displayMode="label"></w2:column>
+							<w2:column width="70" inputType="text" id="userName" displayMode="label"></w2:column>
+							<w2:column width="120" inputType="text" id="executionDate" displayMode="label"></w2:column>
+							<w2:column width="100" inputType="text" id="duration" displayMode="label"></w2:column>
+							<w2:column width="140" inputType="text" id="createdAt" displayMode="label"></w2:column>
+							<w2:column width="140" inputType="text" id="updatedAt" displayMode="label"></w2:column>
+						</w2:row>
+					</w2:gBody>
+
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_testList" pageSize="5" pagingType="0"
+					style="" ev:onclick="scwin.pgl_testList_onclick">
+				</w2:pageList>
+				<xf:group class="pgl_count" id="" style="display: none;">
+					<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_testVo.pageIndex" style=""></w2:span>
+					<w2:span id="span1" label="/" style=""></w2:span>
+					<w2:span id="spn_totalPageCount" label="0" ref="data:dma_testVo.totalPageCount" style=""></w2:span>
+					<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+				</xf:group>
+			</xf:group>
+			<xf:group class="tblbox" id="grp_testInfo" style=""></xf:group>
+			<xf:group class="pop_contents" id="popup_grp" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+				meta_snippetName="0_02 팝업페이지시작" style="position: fixed;top: 50%;left: 50%;transform: translate(-50%, -50%);background: white;padding: 20px;border-radius: 8px;z-index: 1000;border : 1px solid grey;display:none;">
+				<xf:group class="titbox" id="" style="">
+					<xf:group id="" style="" tagname="h3">
+						<w2:textbox class="" id="" label="테스트관리" localeRef="" style=""></w2:textbox>
+						<w2:textbox class="" id="" label="(" style=""></w2:textbox>
+						<w2:textbox class="" id="textbox4" label="등록" localeRef="COMMON_LABEL_00006" style=""></w2:textbox>
+						<w2:textbox class="" id="" label=")" style=""></w2:textbox>
+					</xf:group>
+					<xf:group class="rt" id="" style="">
+						<xf:trigger class="btn_cm refresh" ev:onclick="scwin.btn_reset_onclick" id="trigger13"
+							localeRef="COMMON_BUTTON_00002" style="" type="button">
+							<xf:label><![CDATA[초기화]]></xf:label>
+						</xf:trigger>
+						<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_save_onclick" id="trigger14" localeRef="COMMON_BUTTON_00003"
+							style="" type="button">
+							<xf:label><![CDATA[저장]]></xf:label>
+						</xf:trigger>
+						<xf:trigger class="btn_cm save" ev:onclick="scwin.btn_edit_onclick" id="trigger15" localeRef="COMMON_BUTTON_00003"
+							style="" type="button">
+							<xf:label><![CDATA[저장]]></xf:label>
+						</xf:trigger>
+						<xf:trigger class="btn_cm delete" ev:onclick="scwin.btn_delete_onclick" id="trigger16"
+							localeRef="COMMON_BUTTON_00004" style="" type="button">
+							<xf:label><![CDATA[삭제]]></xf:label>
+						</xf:trigger>
+						<xf:trigger anchorWithGroupClass="" class="btn_cm delete icon" id="esc_btn" meta_snippetCategory="08_버튼"
+							meta_snippetKeyComponent="true" meta_snippetName="8_03 아이콘삭제버튼" style="" type="button" ev:onclick="scwin.esc_btn_onclick">
+							<xf:label><![CDATA[Delete]]></xf:label>
+						</xf:trigger>
+					</xf:group>
+				</xf:group>
+				<xf:group adaptive="layout" adaptiveThreshold="600" class="w2tb tbl" id="" style="" tagname="table">
+					<w2:attributes>
+						<w2:summary></w2:summary>
+					</w2:attributes>
+					<xf:group tagname="colgroup">
+						<xf:group style="width:150px;" tagname="col"></xf:group>
+						<xf:group style="" tagname="col"></xf:group>
+						<xf:group style="width:150px;" tagname="col"></xf:group>
+						<xf:group style="" tagname="col"></xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 고유 ID" localeRef="Test_COLNAME_00001" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.id" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="연결된 업무 ID" localeRef="Test_COLNAME_00002" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.taskId" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 케이스명" localeRef="Test_COLNAME_00003" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.name" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 카테고리" localeRef="Test_COLNAME_00004" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.category" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 실행 시나리오" localeRef="Test_COLNAME_00005" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.scenario" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 입력 데이터" localeRef="Test_COLNAME_00006" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.inputData" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="예상 결과" localeRef="Test_COLNAME_00007" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.expectedResult" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="실제 결과" localeRef="Test_COLNAME_00008" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td"> 
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.actualResult" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 결과" localeRef="Test_COLNAME_00009" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.testResult" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 담당자" localeRef="Test_COLNAME_00010" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.assignee" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 실행일" localeRef="Test_COLNAME_00011" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.executionDate" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="테스트 소요시간(분)" localeRef="Test_COLNAME_00012" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.duration" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="삭제 여부" localeRef="Test_COLNAME_00013" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.isDeleted" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="등록일시" localeRef="Test_COLNAME_00014" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.createdAt" style="width:100%;"></xf:input>
+						</xf:group>
+					</xf:group>
+					<xf:group style="" tagname="tr">
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="수정일시" localeRef="Test_COLNAME_00015" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td">
+							<xf:input class="" id="" placeholder="" ref="data:dmp_testVoDetail.updatedAt" style="width:100%;"></xf:input>
+						</xf:group>
+						<xf:group class="w2tb_th" style="" tagname="th">
+							<w2:textbox class="" id="" label="" ref="" style="" userData2=""></w2:textbox>
+						</xf:group>
+						<xf:group class="w2tb_td" style="" tagname="td"></xf:group>
+					</xf:group>
+				</xf:group>
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/ui/test/TestList.xml
+++ b/src/main/webapp/ui/test/TestList.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+	xmlns:xf="http://www.w3.org/2002/xforms">
+	<head>
+		<w2:type>COMPONENT</w2:type>
+		<w2:buildDate />
+		<w2:MSA />
+		<xf:model>
+			<w2:dataCollection baseNode="map">
+				<w2:dataMap baseNode="map" id="dmp_testVo" style="">
+					<w2:keyInfo>
+						
+						<w2:key dataType="text" id="pageIndex" name="페이지_번호" defaultValue="1"></w2:key>
+						<w2:key dataType="text" id="pageSize" name="페이지_건수" defaultValue="10"></w2:key>
+					</w2:keyInfo>
+					<w2:data use="false"></w2:data>
+				</w2:dataMap>
+				<w2:dataList baseNode="list" id="dlt_testVoList" repeatNode="map" saveRemovedData="true" style="">
+					<w2:columnInfo>
+						<w2:column dataType="text" id="id" name="테스트 고유 ID"></w2:column>
+                        <w2:column dataType="text" id="taskId" name="연결된 업무 ID"></w2:column>
+                        <w2:column dataType="text" id="name" name="테스트 케이스명"></w2:column>
+                        <w2:column dataType="text" id="category" name="테스트 카테고리"></w2:column>
+                        <w2:column dataType="text" id="scenario" name="테스트 실행 시나리오"></w2:column>
+                        <w2:column dataType="text" id="inputData" name="테스트 입력 데이터"></w2:column>
+                        <w2:column dataType="text" id="expectedResult" name="예상 결과"></w2:column>
+                        <w2:column dataType="text" id="actualResult" name="실제 결과"></w2:column>
+                        <w2:column dataType="text" id="testResult" name="테스트 결과"></w2:column>
+                        <w2:column dataType="text" id="assignee" name="테스트 담당자"></w2:column>
+                        <w2:column dataType="text" id="executionDate" name="테스트 실행일"></w2:column>
+                        <w2:column dataType="text" id="duration" name="테스트 소요시간(분)"></w2:column>
+                        <w2:column dataType="text" id="isDeleted" name="삭제 여부"></w2:column>
+                        <w2:column dataType="text" id="createdAt" name="등록일시"></w2:column>
+                        <w2:column dataType="text" id="updatedAt" name="수정일시"></w2:column>
+                       
+					</w2:columnInfo>
+				</w2:dataList>
+				<w2:dataMap baseNode="map" id="dmp_testVoDetail" style="">
+					<w2:keyInfo>
+						
+					</w2:keyInfo>
+				</w2:dataMap>
+			</w2:dataCollection>
+			<w2:workflowCollection></w2:workflowCollection>
+
+			<xf:submission id="sbm_selectTestVoList" ref='data:json,{"id":"dmp_testVo","key":"testVo"}'
+				target='data:json,{"id":"dlt_testVoList","key":"elData.testVoList"}' action="/InsWebApp/TEST001List.pwkjson" method="post"
+				mediatype="application/json" encoding="UTF-8" instance="" replace="" errorHandler="" customHandler="" mode="asynchronous"
+				processMsg="테스트관리 리스트를 조회 중입니다." ev:submit="" ev:submitdone="scwin.sbm_testList_submitdone" ev:submiterror="" abortTrigger="">
+			</xf:submission>
+		</xf:model>
+		<w2:layoutInfo></w2:layoutInfo>
+		<w2:publicInfo method="" />
+		<script lazy="false" type="text/javascript"><![CDATA[
+	scwin.onpageload = function() {		
+		//search_box
+        var cptIbxName = $p.getComponentById("searchComp_1");
+        if(cptIbxName == undefined){
+			search_box.hide();
+        }
+		
+		// 테스트관리 조회
+		scwin.btn_search_onclick();
+	};
+
+	/************************** 이벤트 함수 *************************/
+	
+	/**
+	 * 조회 버튼 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns
+	 * @author 
+	 * @example
+	 */		   
+	scwin.btn_search_onclick = function(e) {
+	
+		// PGAE번호 초기화
+		dmp_testVo.set("pageIndex","1");
+		pgl_testList.setSelectedIndex(1);
+
+		// 서버통신 - 테스트관리 조회
+		$c.sbm.execute($p, sbm_selectTestVoList);
+	};
+	
+	scwin.sbm_testList_submitdone = function(e) {
+
+		// error 수신시
+		var elData = e.responseJSON.elData;
+		var elHeader  = e.responseJSON.elHeader;
+		if(elHeader == null || elHeader == "" || elHeader == "undefiend" || elHeader.resSuc == false) {
+			$c.win.alert(`에러코드 : ${elHeader.resCode}\n에러메시지 : ${elHeader.resMsg}`);
+			return false;
+		}
+
+		// 테스트관리 dataMap 초기화
+		dmp_testVoDetail.setEmptyValue();
+
+		// 총 레코드 수 업데이트
+        spn_listCnt.setLabel(elData.totalCount);
+        
+        // 데이터를 그리드에 셋팅
+        dlt_testVoList.setJSON(elData.testVoList);
+        
+        // 페이지 네비게이터 업데이트
+        var totalPageCount = Math.ceil(elData.totalCount / dmp_testVo.get("pageSize"));
+        pgl_testList.setCount(totalPageCount);
+        
+		// 페이징 정보 업데이트
+        spn_totalPageCount.setValue(totalPageCount);
+        spn_pageIndex.setValue(dmp_testVo.get("pageIndex"));
+        pgl_testList.setSelectedIndex(dmp_testVo.get("pageIndex"));
+	};		
+
+	/**
+	 * 페이지 번호 클릭 이벤트
+	 * @date
+	 * @memberOf
+	 * @param 
+	 * @returns 
+	 * @author 
+	 * @example
+	 */
+	scwin.pgl_testList_onclick = function(idx) {
+	
+		// 페이지 번호 세팅
+		dmp_testVo.set( "pageIndex" , idx ); 
+		// 서버통신 - 사원목록 조회
+		$c.sbm.execute($p, sbm_selectTestVoList);
+	};
+
+]]></script>
+	</head>
+	<body ev:onpageload="scwin.onpageload">
+		<xf:group class="sub_contents " id="" style="">
+			<xf:group class="pgtbox" id="" style="">
+				<w2:textbox class="pgt_tit" id="" label="테스트관리" style="" tagname="" />
+			</xf:group>
+			<xf:group class="schbox" id="search_box" style="">
+				<xf:group class="schbox_inner" id="" style="">
+					<xf:group adaptive="layout" adaptiveThreshold="1200" class="w2tb tbl" id="" style="width:Infinity%;" tagname="table">
+						<w2:attributes>
+							<w2:summary />
+						</w2:attributes>
+						<xf:group tagname="colgroup">
+							
+						</xf:group>
+						<xf:group class="" id="" style="" tagname="tr">
+							<xf:group class="" id="" style="" tagname="tr">
+								
+							</xf:group>
+						</xf:group>
+					</xf:group>
+				</xf:group>
+				<xf:group class="btn_schbox" id="" style="">
+					<xf:trigger class="btn_cm sch" disabled="" escape="false" id="btn_search" style="" type="button" ev:onclick="scwin.btn_search_onclick" localeRef="COMMON_BUTTON_00001">
+						<xf:label><![CDATA[조회]]></xf:label>
+					</xf:trigger>
+				</xf:group>
+			</xf:group>
+			<xf:group class="titbox" id="" style="">
+				<xf:group class="count" id="">
+					<w2:span id="" label="총" localeRef="COMMON_LABEL_00002" style=""></w2:span>
+    				<w2:span class="num" id="spn_listCnt" label="0" ref="" style=""></w2:span>
+    				<w2:span id="" label="건" localeRef="COMMON_LABEL_00003" style=""></w2:span>
+    			</xf:group>
+			</xf:group>
+			<xf:group adaptiveThreshold="" class="gvwbox" id="" style="">
+				<w2:gridView autoFit="allColumn" checkReadOnlyOnPasteEnable="" class="gvw" dataList="data:dlt_testVoList"
+					defaultCellHeight="26" focusMode="row" id="grd_list" scrollByColumn="false" scrollByColumnAdaptive="false" style="height: 150px;"
+					visibleRowNum="10" ev:oncellclick="scwin.grd_list_oncellclick" readOnly="true">
+					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
+					<w2:header style="" id="header2">
+						<w2:row style="" id="row3">
+							<w2:column width="70" inputType="text" style="" id="column1" value="테스트 고유 ID" displayMode="label" localeRef="Test_COLNAME_00001"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column2" value="연결된 업무 ID" displayMode="label" localeRef="Test_COLNAME_00002"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column3" value="테스트 케이스명" displayMode="label" localeRef="Test_COLNAME_00003"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column4" value="테스트 카테고리" displayMode="label" localeRef="Test_COLNAME_00004"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column5" value="테스트 실행 시나리오" displayMode="label" localeRef="Test_COLNAME_00005"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column6" value="테스트 입력 데이터" displayMode="label" localeRef="Test_COLNAME_00006"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column7" value="예상 결과" displayMode="label" localeRef="Test_COLNAME_00007"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column8" value="실제 결과" displayMode="label" localeRef="Test_COLNAME_00008"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column9" value="테스트 결과" displayMode="label" localeRef="Test_COLNAME_00009"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column10" value="테스트 담당자" displayMode="label" localeRef="Test_COLNAME_00010"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column11" value="테스트 실행일" displayMode="label" localeRef="Test_COLNAME_00011"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column12" value="테스트 소요시간(분)" displayMode="label" localeRef="Test_COLNAME_00012"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column13" value="삭제 여부" displayMode="label" localeRef="Test_COLNAME_00013"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column14" value="등록일시" displayMode="label" localeRef="Test_COLNAME_00014"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="column15" value="수정일시" displayMode="label" localeRef="Test_COLNAME_00015"></w2:column>
+                           
+						</w2:row>
+					</w2:header>
+					<w2:gBody style="" id="gBody2">
+						<w2:row style="" id="row4">
+							<w2:column width="70" inputType="text" style="" id="id" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="taskId" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="name" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="category" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="scenario" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="inputData" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="expectedResult" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="actualResult" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="testResult" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="assignee" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="executionDate" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="duration" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="isDeleted" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="createdAt" value="" displayMode="label"></w2:column>
+                            <w2:column width="70" inputType="text" style="" id="updatedAt" value="" displayMode="label"></w2:column>
+                           
+						</w2:row>
+					</w2:gBody>
+				</w2:gridView>
+			</xf:group>
+			<xf:group class="pglbox" id="" style="">
+				<w2:pageList class="pgl" displayButtonType="display" displayFormat="#" id="pgl_testList" pageSize="5" pagingType="0"
+					style="" ev:onclick="scwin.pgl_testList_onclick">
+				</w2:pageList>	
+				<xf:group class="pgl_count" id="" style="display: none;">
+    				<w2:span class="num" id="spn_pageIndex" label="0" ref="data:dma_testVo.pageIndex" style=""></w2:span>
+    				<w2:span id="span1" label="/" style=""></w2:span>
+    				<w2:span id="spn_totalPageCount" label="0" ref="data:dma_testVo.totalPageCount" style=""></w2:span>
+    				<w2:span id="span2" label="페이지" localeRef="COMMON_LABEL_00005" style=""></w2:span>
+    			</xf:group>		
+			</xf:group>
+		</xf:group>
+	</body>
+</html>

--- a/src/main/webapp/websquare/config.js
+++ b/src/main/webapp/websquare/config.js
@@ -95,7 +95,7 @@ export default {
       "@value": "false"
     },
     "stylesheet": {
-      "@earlyImportList": "/InsWebApp/cm/css/base.css,/InsWebApp/cm/css/common.css,/InsWebApp/cm/css/m_content.css,/InsWebApp/cm/css/swiper.css",
+      "@earlyImportList": "/InsWebApp/cm/css/base.css,/InsWebApp/cm/css/common.css,/InsWebApp/cm/css/swiper.css,/InsWebApp/cm/css/m_content.css",
       "@enable": "true",
       "@import": "link",
       "@value": "stylesheet_ext.css"

--- a/src/main/webapp/websquare/config.xml
+++ b/src/main/webapp/websquare/config.xml
@@ -33,7 +33,7 @@
     <byteCheckEncoding value="euc-kr"/>
     <initScript value="false"/>
     <clearMemory value="false"/>
-    <stylesheet earlyImportList="/InsWebApp/cm/css/base.css,/InsWebApp/cm/css/common.css,/InsWebApp/cm/css/m_content.css,/InsWebApp/cm/css/swiper.css" enable="true" import="link" value="stylesheet_ext.css"/>
+    <stylesheet earlyImportList="/InsWebApp/cm/css/base.css,/InsWebApp/cm/css/common.css,/InsWebApp/cm/css/swiper.css,/InsWebApp/cm/css/m_content.css" enable="true" import="link" value="stylesheet_ext.css"/>
     <mediaInfo>
         <media maxWidth="" minWidth="1025" name="desktop"/>
         <media maxWidth="1024" minWidth="768" name="tablet"/>


### PR DESCRIPTION
## 🔧 주요 변경사항

### 데이터베이스 최적화
- **assignee 컬럼 타입 변경**: `DEFECT.assignee` VARCHAR → INT로 변경
  - 기존: `assignee VARCHAR(50)` (backshin, devlee, frontjo 등)
  - 변경: `assignee INT` (USERS.user_id 참조)
  - 효과: JOIN 성능 향상 및 참조 무결성 보장

- **상태 코드 단순화**: 결함 상태 5개(신규/진행중/수정완료/재오픈/종료) → 3개(신규/진행중/완료)로 단순화
  - 재오픈 기능은 '완료→진행중' 상태 변경으로 대체

### 쿼리 최적화
- **테스트 관리**: TASK, USERS 테이블 LEFT JOIN 추가
  ```sql
  LEFT JOIN TASK task ON test.TASK_ID = task.ID
  LEFT JOIN USERS user ON test.ASSIGNEE = user.USER_ID
  ```
  - 업무명(taskName)과 담당자명(userName) 조회 추가
- **결함 관리**: TEST, USERS 테이블 LEFT JOIN 추가
  ```sql
  LEFT JOIN TEST t ON d.TEST_ID = t.ID
  LEFT JOIN USERS u ON d.ASSIGNEE = u.USER_ID
  ```
  - 테스트 케이스명(testName)과 담당자명(userName) 조회 추가

### UI/UX 개선
- **그리드 컬럼 너비 조정**:
  - 테스트 케이스명: 70px → 200px (긴 텍스트 표시를 위해 확대)
  - 연결된 업무명: 70px → 200px (업무명 전체 표시)
  - 담당자: 70px → 120px (사용자명 전체 표시)
  - 등록/수정일시: 70px → 140px (날짜시간 형식 전체 표시)
  - 우선순위/상태: 70px → 100px (색상 뱃지 표시 공간 확보)
- **색상 표시 기능**:
  - **테스트 결과별 색상 뱃지**:
    - 🟢 통과/PASS: 초록색 배경 (#e6ffe6, 텍스트: #009900)
    - 🔴 실패/FAIL: 빨간색 배경 (#ffe6e6, 텍스트: #cc0000)
    - 🟠 대기/PENDING: 주황색 배경 (#fff2e6, 텍스트: #cc6600)
  - **결함 우선순위별 색상 뱃지**:
    - 🔴 긴급(CR): 빨간색 배경 (#ffe6e6, 텍스트: #cc0000, 굵은 글씨)
    - 🟠 높음(HI): 주황색 배경 (#fff2e6, 텍스트: #cc6600, 굵은 글씨)
    - 🔵 보통(MD): 파란색 배경 (#e6f3ff, 텍스트: #0066cc)
    - ⚪ 낮음(LO): 회색 배경 (#f5f5f5, 텍스트: #666666)
  
  ---
  **⚠️ 색상 뱃지 적용 안되서 아직 작업중입니다**
  
- **상태별 그리드 분리**: 결함 관리 화면에서 신규/진행중/완료 탭 구분
  - 각 상태별로 독립된 그리드 표시
  - 상태 전환 시 해당 그리드로 자동 이동
  - 워크플로우 시각화로 업무 진행 상황 한눈에 파악 가능