### PR TITLE
feat: 로그인 back부분 sha256 방식 암호화, 헤더 팝업에  로그아웃버튼 추가

### DIFF
--- a/src/main/java/com/demo/proworks/cmmn/ElSha256Crypto.java
+++ b/src/main/java/com/demo/proworks/cmmn/ElSha256Crypto.java
@@ -1,0 +1,41 @@
+package com.demo.proworks.cmmn;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import org.springframework.stereotype.Component;
+
+import com.inswave.elfw.security.ElAbstractCrypto;
+
+@Component("elSha256Crypto")
+public class ElSha256Crypto extends ElAbstractCrypto {
+    
+    // 고정 salt (운영 환경에서는 사용자별로 동적 salt를 사용하는 것이 더 안전)
+    private static final String SALT = "Proworks$Secure#Salt123";
+
+    @Override
+    public String getEncrypt(String cryptoKind, String plainText) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            // Salt를 plainText 앞뒤로 추가
+            String saltedText = SALT + plainText + SALT;
+            byte[] hash = digest.digest(saltedText.getBytes(StandardCharsets.UTF_8));
+
+            // 바이트 배열을 16진수 문자열로 변환
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("SHA-256 암호화 실패", e);
+        }
+    }
+
+    @Override
+    public String getDecrypt(String cryptoKind, String encryptedText) throws Exception {
+        throw new UnsupportedOperationException("SHA-256은 복호화할 수 없습니다.");
+    }	
+}

--- a/src/main/java/com/demo/proworks/cmmn/ProworksLoginAdapter.java
+++ b/src/main/java/com/demo/proworks/cmmn/ProworksLoginAdapter.java
@@ -15,6 +15,9 @@ import com.inswave.elfw.login.LoginException;
 import com.inswave.elfw.login.LoginInfo;
 import com.inswave.elfw.util.ElBeanUtils;
 
+import com.inswave.elfw.security.ElAbstractCrypto;
+
+
 /**
  * @subject		: ProworksLoginAdapter.java 
  * @description : 프로젝트 로그인 어댑터
@@ -52,13 +55,22 @@ public class ProworksLoginAdapter extends LoginAdapter {
 	
 		// 로그인 체크를 수행  (샘플 예제)
 		try{
-		    String pw = (String)params[0];
+				
+			String pw = (String) params[0];
+			
+			// SHA256로 비밀번호 암호화
+	        ElAbstractCrypto elSha256Crypto = (ElAbstractCrypto) ElBeanUtils.getBean("elSha256Crypto"); // Bean 이름에 맞게 조정
+	        String hashedInput = elSha256Crypto.getEncrypt(null, pw);        
+	        pw = hashedInput;
+
+	        // usersVo에 입력된 id 및 암호화된 pw값 등록
 		    UsersService usersService = (UsersService)ElBeanUtils.getBean("usersServiceImpl");
 		    UsersVo usersVo = new UsersVo();
 		    usersVo.setAccountId(id);
 		    usersVo.setAccountPwd(pw);
 		    
 		    UsersVo resUsersVo = usersService.selectUsers(usersVo);
+		    
 		    if(resUsersVo == null){
 		        throw new LoginException("EL.ERROR.LOGIN.0001");
 		    }

--- a/src/main/webapp/ui/header.xml
+++ b/src/main/webapp/ui/header.xml
@@ -32,6 +32,7 @@ scwin.SERVER_TIME = "";
 scwin.USER_ID = "";
 scwin.USER_NAME = "";
 
+
 scwin.onpageload = function() {
     scwin.SERVER_TIME = $c.date.getServerDateTime("yyyy-MM-dd hh:mm:ss");
     serverTime.setValue(scwin.SERVER_TIME);
@@ -62,10 +63,9 @@ scwin.sbm_selectUsersMapping_submitdone = function (e) {
 
     selectBoxProjectName.setNodeSet("data:dlt_projectName", "pjtName", "pjtId")
     
-    // TextBox와 그룹ID Bind
-    var grpIdData = data[0].grpName;
-    textGrpId.setValue(grpIdData);
-
+    // TextBox에 그룹명 초기값 Bind
+    textGrpName.setValue("");
+    
     // TextBox와 사용자명 Bind
     var nameData = data[0].name;
     textName1.setValue(nameData);
@@ -96,12 +96,17 @@ scwin.accountImg_onclick = function (e) {
         popupName: "계정 관리"
     };
 
-    $p.openPopup("popup_test.xml", options);
+    $p.openPopup("popup_header.xml", options);
 };
 
 scwin.selectBoxProjectName_onchange = function (info) {
+
     var selectedPjtId = info.newValue; // 변경된 프로젝트 id
     var grpId = dlt_projectName.getMatchedColumnData("pjtId", selectedPjtId, "grpId"); // pjtId로 데이터 리스트에서 그룹아이디 조회
+
+    // TextBox와 선택한 프로젝트에 따른 그룹명 표시
+    var grpName = dlt_projectName.getMatchedColumnData("pjtId", selectedPjtId, "grpName"); // pjtId로 데이터 리스트에서 그룹명 조회
+    textGrpName.setValue(grpName);
 
     var parentScwin = $p.getParentWindow().scwin;
 
@@ -129,7 +134,7 @@ scwin.selectBoxProjectName_onchange = function (info) {
     				<xf:choices></xf:choices>
     			</xf:select1>
     			<xf:group style="width:572px;height:40px;" id="" class="rt">
-    				<w2:span style="color:#000000; min-width:100px; font-weight:bold;" id="textGrpId" label="#GRP_ID#" class=""></w2:span>
+    				<w2:span style="color:#000000; min-width:100px; font-weight:bold;" id="textGrpName" label="#GRP_NAME#" class=""></w2:span>
     				<w2:span style="color:#000000; min-width:100px; font-weight:bold;" id="textName1" label="#NAME#" class=""></w2:span>
     				<w2:span style="margin-left: 50px; margin-right: 5px; font-weight:bold;" id="span6" label="접속시간 : "></w2:span>
     				<w2:span style="font-weight:bold;" id="serverTime" label="#SERVER_TIME#"></w2:span>

--- a/src/main/webapp/ui/login.xml
+++ b/src/main/webapp/ui/login.xml
@@ -41,6 +41,14 @@ scwin.pw_input_onclick = function (e) {
 
 // 로그인 버튼 클릭시 로그인 처리
 scwin.btn_login_onclick = function (e) {
+    var userId = $p.getComponentById("id_input").getValue();
+    var plainPassword = $p.getComponentById("pw_input").getValue();
+
+    if (!userId || !plainPassword) {
+        alert("아이디와 비밀번호를 입력하세요.");
+        return;
+    }
+
     $c.sbm.execute(sbm_login);
 };
 
@@ -59,8 +67,7 @@ scwin.sbm_login_submitdone = function (e) {
             alert(elHeader.resMsg);
         }
     }
-};
-]]></script>
+};]]></script>
     </head>
     <body ev:onpageload="scwin.onpageload">
     	<xf:group class="sub_contents" id="" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true" meta_snippetName="0_01 페이지시작"
@@ -103,7 +110,7 @@ scwin.sbm_login_submitdone = function (e) {
     				<xf:input ref="data:dma_login.pw" meta_snippetCategory="10_입력폼" meta_snippetName="10_01 InputBox"
     					ev:onclick="scwin.pw_input_onclick" meta_snippetKeyComponent="true"
     					style="margin-top: 10px;margin-bottom: 60px;border-radius: 8px;width: 100%;" id="pw_input" placeholder="" class=""
-    					initValue="패스워드를 입력하세요">
+    					initValue="패스워드를 입력하세요" ev:onkeydown="scwin.pw_input_onkeydown">
     				</xf:input>
     				<xf:group meta_snippetCategory="08_버튼" meta_snippetName="8_04 전체제어버튼" meta_snippetKeyComponent="true" style="" id=""
     					class="btnbox lt">

--- a/src/main/webapp/ui/popup_header.xml
+++ b/src/main/webapp/ui/popup_header.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:w2="http://www.inswave.com/websquare" xmlns:xf="http://www.w3.org/2002/xforms">
+    <head>
+        <w2:type>COMPONENT</w2:type>
+        <w2:buildDate/>
+        <w2:MSA/>
+        <xf:model>
+        	<w2:dataCollection baseNode="map">
+        		<w2:dataMap baseNode="map" id="dma_logout">
+        			<w2:keyInfo>
+        				<w2:key dataType="text" name="아이디" id="id"></w2:key>
+        			</w2:keyInfo>
+        		</w2:dataMap>
+        	</w2:dataCollection>
+        	<w2:workflowCollection />
+        </xf:model>
+        <w2:layoutInfo/>
+        <w2:publicInfo method=""/>
+        <script lazy="false" type="text/javascript"><![CDATA[
+scwin.onpageload = function() {
+	
+};
+
+// 마이페이지 이동 버튼
+scwin.btn_myPage_onclick = function (e) {
+    alert("마이페이지로 이동합니다.");
+    location.href = "/InsWebApp/websquare/websquare.html?w2xPath=/InsWebApp/ui/myPage.xml";
+};
+
+// 회원탈퇴 처리 버튼
+scwin.btn_deleteAccount_onclick = function (e) {
+    alert("회원탈퇴 처리되었습니다.");
+ 
+};
+
+// 로그아웃 버튼
+scwin.btn_logout_onclick = function (e) {
+    WebSquare.cookie.delCookie("usrId");
+    location.href = "/InsWebApp/websquare/websquare.html?w2xPath=/InsWebApp/ui/login.xml";
+};
+]]></script>
+    </head>
+    <body ev:onpageload="scwin.onpageload">
+    	<xf:group class="pop_contents" id="" meta_snippetCategory="00_화면시작" meta_snippetKeyComponent="true"
+    		meta_snippetName="0_02 팝업페이지시작">
+    		<xf:group class="pgtbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_01 페이지타이틀"
+    			style="">
+    			<xf:trigger type="button" style="height: 30px;width: 100%;border-radius: 8px;" id="btn_myPage" ev:onclick="scwin.btn_myPage_onclick">
+    				<xf:label><![CDATA[마이페이지]]></xf:label>
+    			</xf:trigger>
+    		</xf:group>
+    		<xf:group class="pgtbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_01 페이지타이틀"
+    			style="">
+    			<xf:trigger id="btn_deleteAccount" style="height: 30px;width: 100%;border-radius: 8px;" type="button" ev:onclick="scwin.btn_deleteAccount_onclick">
+    				<xf:label><![CDATA[회원탈퇴]]></xf:label>
+    			</xf:trigger>
+    		</xf:group>
+    		<xf:group class="pgtbox" id="" meta_snippetCategory="02_타이틀" meta_snippetKeyComponent="true" meta_snippetName="2_01 페이지타이틀"
+    			style="">
+    			<xf:trigger id="btn_logout" style="height: 30px;width: 100%;border-radius: 8px;" type="button" ev:onclick="scwin.btn_logout_onclick">
+    				<xf:label><![CDATA[로그아웃]]></xf:label>
+    			</xf:trigger>
+    		</xf:group>
+    	</xf:group>
+    </body>
+</html>


### PR DESCRIPTION
- ElSha256Crpyto.java: sha256 암호화  알고리즘 추가, loginadapter에 bean 등록
- DB에서 users 테이블에 테스트용으로 id=3,5 비밀번호 sha256로 암호화된 값으로 대체
- 헤더 팝업: popup_header.xml 추가
- 헤더에 오른쪽 상단  계정 아이콘 클릭시 팝업 버튼 열리고 로그아웃 버튼클릭시 로그아웃
- 선택된 프로젝트별로 그룹명 변경 